### PR TITLE
docs: update FURPS.md — mark v0.1 complete, update CLI examples for lez-cli

### DIFF
--- a/docs/FURPS.md
+++ b/docs/FURPS.md
@@ -1,6 +1,6 @@
 # Multisig PoC — FURPS Specification
 
-> **Status:** Draft — 2026-02-16 (updated 2026-02-21)
+> **Status:** v0.1 Complete — 2026-02-26
 > **Scope:** Public mode only, basic M-of-N threshold
 > **Target:** LEZ Testnet
 
@@ -31,34 +31,37 @@
 
 ## Usability (U)
 
-### U1. CLI Commands *(partially implemented — needs update for proposal PDA flow)*
+### U1. CLI Commands
 ```
+# Generate IDL first (if not already done)
+cargo run --bin generate_idl > multisig_idl.json
+
 # Create 2-of-3 multisig
-lez-wallet multisig create --threshold 2 --member <pk1> --member <pk2> --member <pk3>
+cargo run --bin multisig -- --idl multisig_idl.json create-multisig --threshold 2 --member <pk1> --member <pk2> --member <pk3>
 
 # View multisig info
-lez-wallet multisig info --account <multisig_id>
+cargo run --bin multisig -- --idl multisig_idl.json multisig-info --account <multisig_id>
 
 # Propose transfer (creates proposal PDA on-chain)
-lez-wallet multisig propose --multisig <id> --to <recipient> --amount 100
+cargo run --bin multisig -- --idl multisig_idl.json propose --multisig <id> --to <recipient> --amount 100
 
 # Approve proposal (each member in their own tx)
-lez-wallet multisig approve --multisig <id> --proposal <index>
+cargo run --bin multisig -- --idl multisig_idl.json approve --multisig <id> --proposal <index>
 
 # Reject proposal
-lez-wallet multisig reject --multisig <id> --proposal <index>
+cargo run --bin multisig -- --idl multisig_idl.json reject --multisig <id> --proposal <index>
 
 # Execute once threshold is met
-lez-wallet multisig execute --multisig <id> --proposal <index>
+cargo run --bin multisig -- --idl multisig_idl.json execute --multisig <id> --proposal <index>
 
 # Propose adding a member (creates config change proposal)
-lez-wallet multisig add-member --multisig <id> --member <new_pk>
+cargo run --bin multisig -- --idl multisig_idl.json add-member --multisig <id> --member <new_pk>
 
 # Propose removing a member
-lez-wallet multisig remove-member --multisig <id> --member <pk>
+cargo run --bin multisig -- --idl multisig_idl.json remove-member --multisig <id> --member <pk>
 
 # Propose changing threshold
-lez-wallet multisig change-threshold --multisig <id> --threshold <new_M>
+cargo run --bin multisig -- --idl multisig_idl.json change-threshold --multisig <id> --threshold <new_M>
 ```
 
 ---
@@ -86,6 +89,7 @@ lez-wallet multisig change-threshold --multisig <id> --threshold <new_M>
 - **S2**: Integration test: create → fund → propose → approve → execute → verify balances
 - **S3**: SPEC.md documents full account model, PDA derivation, instruction set, validation rules
 - **S4**: Gap analysis in docs/gap-analysis.md
+- **S5**: lez-cli wrapper — thin CLI binary wrapping lez-cli library for IDL-driven operations
 
 ---
 
@@ -116,6 +120,5 @@ Due to LEZ runtime validation rules, member accounts must be **fresh keypairs** 
 
 ## Known Limitations (PoC Scope)
 
-- CLI needs update for proposal PDA flow
 - No `CloseProposal` to reclaim executed/rejected proposal storage
 - No time-lock between threshold reached and execution


### PR DESCRIPTION
## Summary
- Updated status from Draft to v0.1 Complete (2026-02-26)
- Removed partially-implemented note from U1 CLI section — CLI is fully implemented
- Replaced `lez-wallet multisig` CLI examples with `cargo run --bin multisig -- --idl multisig_idl.json` equivalents
- Added S5: lez-cli wrapper to Supportability section
- Removed "CLI needs update for proposal PDA flow" from Known Limitations (done)

## Test plan
- [ ] Review rendered FURPS.md for formatting correctness
- [ ] Verify CLI examples use correct `cargo run --bin multisig` syntax
- [ ] Verify Known Limitations still lists remaining two items
- [ ] Verify S5 entry is present in Supportability

🤖 Generated with [Claude Code](https://claude.com/claude-code)