### PR TITLE
feat: update to latest LEZ (ffcbc159) and SPEL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Install spel-client-gen
         run: |
           cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --branch main \
+            --git https://github.com/jimmy-claw/spel.git \
+            --branch jimmy/update-lssa-latest \
             spel-client-gen \
             --locked
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+  LSSA_REF: "ffcbc15972adbf557939bf3e2852af276422631b"
 
 jobs:
   unit-tests:
@@ -30,8 +30,8 @@ jobs:
       - name: Install spel-client-gen
         run: |
           cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --branch main \
+            --git https://github.com/jimmy-claw/spel.git \
+            --branch jimmy/update-lssa-latest \
             spel-client-gen \
             --locked
 
@@ -99,8 +99,8 @@ jobs:
       - name: Install spel-client-gen
         run: |
           cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --branch main \
+            --git https://github.com/jimmy-claw/spel.git \
+            --branch jimmy/update-lssa-latest \
             spel-client-gen \
             --locked
 
@@ -140,20 +140,20 @@ jobs:
         id: cache-seq
         uses: actions/cache@v4
         with:
-          path: /tmp/lssa/target/release/sequencer_runner
+          path: /tmp/lssa/target/release/sequencer_service
           key: sequencer-${{ steps.lssa-hash.outputs.hash }}
 
       - name: Build sequencer
         if: steps.cache-seq.outputs.cache-hit != 'true'
         run: |
           cd /tmp/lssa
-          cargo build --release --features standalone -p sequencer_runner
+          cargo build --release --features standalone -p sequencer_service
 
       - name: Start sequencer
         run: |
           cd /tmp/lssa
           rm -rf rocksdb
-          /tmp/lssa/target/release/sequencer_runner sequencer_runner/configs/debug > /tmp/sequencer.log 2>&1 &
+          /tmp/lssa/target/release/sequencer_service sequencer/service/configs/debug/sequencer_config.json > /tmp/sequencer.log 2>&1 &
           echo "Waiting for sequencer..."
           for i in $(seq 1 60); do
             CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3040 2>/dev/null || echo "000")

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ demo-wallet/
 lez-multisig-ffi/src/multisig_idl.json
 lez-multisig-ffi/src/multisig.rs
 lez-multisig-ffi/src/generated/
+multisig.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,7 +3043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-blockchain-blend-crypto"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-message"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "blake2",
  "derivative",
@@ -3079,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-proofs"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.3.5",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "derivative",
@@ -3113,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3144,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-prover"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "logos-blockchain-circuits-utils",
  "tempfile",
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "dirs",
 ]
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-common-http-client"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "futures",
  "hex",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-core"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "ark-ff 0.4.2",
  "bincode",
@@ -3211,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "cfg_eval",
  "logos-blockchain-pol",
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "bytes",
  "futures",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-groth16"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-http-api-common"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "axum",
  "logos-blockchain-core",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3303,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3313,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-ledger"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-network-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "futures",
@@ -3355,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poc"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-pol"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "astro-float",
  "logos-blockchain-circuits-prover",
@@ -3390,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poq"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3407,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poseidon2"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -3418,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-services-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "futures",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-storage-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3451,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-time-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "futures",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-tracing"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -3493,7 +3493,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "async-trait",
  "blake2",
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utxotree"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "ark-ff 0.4.2",
  "logos-blockchain-groth16",
@@ -3524,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-witness-generator"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "tempfile",
 ]
@@ -3532,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-zksign"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#f4d67b290bce08f36d82aba5609069077d83239d"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -5531,7 +5531,7 @@ dependencies = [
 [[package]]
 name = "spel"
 version = "0.1.0"
-source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#32720ffa01bc14f6d67c0ebfb86c87916ea0eb77"
 dependencies = [
  "base58",
  "borsh",
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "spel-framework"
 version = "0.1.0"
-source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#32720ffa01bc14f6d67c0ebfb86c87916ea0eb77"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -5561,7 +5561,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#32720ffa01bc14f6d67c0ebfb86c87916ea0eb77"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -5575,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-macros"
 version = "0.1.0"
-source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#32720ffa01bc14f6d67c0ebfb86c87916ea0eb77"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,7 +672,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -2704,10 +2704,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-http-client",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-http-client 0.26.0",
  "jsonrpsee-proc-macros",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.26.0",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tracing",
@@ -2724,7 +2724,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http",
- "jsonrpsee-core",
+ "jsonrpsee-core 0.26.0",
  "pin-project",
  "rustls",
  "rustls-pki-types",
@@ -2740,6 +2740,26 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348ee569eaed52926b5e740aae20863762b16596476e943c9e415a6479021622"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types 0.24.10",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
@@ -2751,7 +2771,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.26.0",
  "pin-project",
  "rustc-hash",
  "serde",
@@ -2759,9 +2779,34 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50c389d6e6a52eb7c3548a6600c90cf74d9b71cb5912209833f00a5479e9a01"
+dependencies = [
+ "async-trait",
+ "base64",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core 0.24.10",
+ "jsonrpsee-types 0.24.10",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2775,15 +2820,15 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
  "rustls",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -2798,6 +2843,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.24.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f05e0028e55b15dbd2107163b3c744cd3bb4474f193f95d9708acbf5677e44"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2819,9 +2876,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7902885de4779f711a95d82c8da2d7e5f9f3a7c7cfa44d51c067fd1c29d72a3c"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "tower",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
+ "tower 0.5.3",
 ]
 
 [[package]]
@@ -2832,9 +2889,9 @@ checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "tower",
+ "jsonrpsee-core 0.26.0",
+ "jsonrpsee-types 0.26.0",
+ "tower 0.5.3",
  "url",
 ]
 
@@ -2927,11 +2984,14 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "common",
+ "hex",
+ "jsonrpsee-http-client 0.24.10",
  "lez-multisig-ffi",
  "multisig_core",
  "nssa",
  "nssa_core",
  "risc0-zkvm",
+ "sequencer_service_rpc",
  "token_core",
  "tokio",
 ]
@@ -4699,7 +4759,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -6031,7 +6091,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6046,6 +6106,21 @@ dependencies = [
  "bytes",
  "prost 0.14.3",
  "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6080,7 +6155,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array 0.14.7",
 ]
 
@@ -19,8 +19,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.4.4",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -31,7 +31,7 @@ checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -67,7 +67,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -623,6 +623,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ata_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
+dependencies = [
+ "nssa_core",
+ "risc0-zkvm",
+ "serde",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,18 +764,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcoin-io"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
 name = "bitcoin_hashes"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
- "bitcoin-io",
  "hex-conservative",
 ]
 
@@ -803,6 +806,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -893,6 +905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +956,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,13 +986,13 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cipher",
- "cpufeatures",
+ "cipher 0.5.1",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -986,8 +1013,19 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1046,9 +1084,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "anyhow",
  "base64",
@@ -1057,14 +1105,10 @@ dependencies = [
  "log",
  "logos-blockchain-common-http-client",
  "nssa",
- "nssa_core",
- "reqwest",
  "serde",
- "serde_json",
  "serde_with",
  "sha2",
  "thiserror 2.0.18",
- "url",
 ]
 
 [[package]]
@@ -1086,7 +1130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1168,6 +1212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,12 +1265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1227,7 +1289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1434,9 +1496,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -1634,16 +1696,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "env_filter"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
- "humantime",
- "is-terminal",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1825,6 +1897,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,6 +1996,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,12 +2116,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2103,6 +2225,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a79f2aff40c18ab8615ddc5caa9eb5b96314aef18fe5823090f204ad988e813"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2134,6 +2275,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "rustls-pki-types",
  "tokio",
@@ -2387,6 +2529,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,17 +2551,6 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2478,6 +2618,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2695,147 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3f48dc3e6b8bd21e15436c1ddd0bc22a6a54e8ec46fedd6adf3425f396ec6a"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf36eb27f8e13fa93dcb50ccb44c417e25b818cfa1a481b5470cd07b19c60b98"
+dependencies = [
+ "base64",
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "http",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-timer",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "jsonrpsee-types",
+ "pin-project",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
+dependencies = [
+ "base64",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "rustls",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da3f8ab5ce1bb124b6d082e62dffe997578ceaf0aeb9f3174a214589dc00f07"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
+dependencies = [
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7902885de4779f711a95d82c8da2d7e5f9f3a7c7cfa44d51c067fd1c29d72a3c"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -2510,17 +2859,16 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "aes-gcm",
  "anyhow",
- "base58",
  "bip39",
  "common",
  "hex",
@@ -2530,7 +2878,6 @@ dependencies = [
  "nssa",
  "nssa_core",
  "rand 0.8.5",
- "secp256k1",
  "serde",
  "sha2",
  "thiserror 2.0.18",
@@ -2602,6 +2949,7 @@ dependencies = [
  "nssa",
  "nssa_core",
  "reqwest",
+ "sequencer_service_rpc",
  "serde",
  "serde_json",
  "sha2",
@@ -2615,7 +2963,7 @@ version = "0.1.0"
 dependencies = [
  "multisig_program",
  "serde_json",
- "spel-framework 0.1.0 (git+https://github.com/logos-co/spel.git?rev=e45857e)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -2695,7 +3043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-blockchain-blend-crypto"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -2709,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-message"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "blake2",
  "derivative",
@@ -2731,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-proofs"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.3.5",
@@ -2749,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "derivative",
@@ -2765,7 +3113,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2796,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-prover"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "logos-blockchain-circuits-utils",
  "tempfile",
@@ -2805,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "dirs",
 ]
@@ -2813,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-common-http-client"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "futures",
  "hex",
@@ -2833,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-core"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "ark-ff 0.4.2",
  "bincode",
@@ -2863,7 +3211,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "cfg_eval",
  "logos-blockchain-pol",
@@ -2879,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "bytes",
  "futures",
@@ -2896,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-groth16"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -2914,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-http-api-common"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "axum",
  "logos-blockchain-core",
@@ -2929,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2955,7 +3303,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2965,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-ledger"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -2990,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-network-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3007,7 +3355,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poc"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3023,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-pol"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "astro-float",
  "logos-blockchain-circuits-prover",
@@ -3042,7 +3390,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poq"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3059,7 +3407,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poseidon2"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -3070,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-services-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3085,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-storage-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3103,7 +3451,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-time-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3122,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-tracing"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -3145,11 +3493,11 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "async-trait",
  "blake2",
- "cipher",
+ "cipher 0.4.4",
  "const-hex",
  "humantime",
  "overwatch",
@@ -3162,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utxotree"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "ark-ff 0.4.2",
  "logos-blockchain-groth16",
@@ -3176,7 +3524,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-witness-generator"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "tempfile",
 ]
@@ -3184,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-zksign"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#6b42706177dbbbde00db30d4ceca76e252cc1026"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git#0100c8594f9c4d067907d5c63fc1a69dc41606e0"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3384,7 +3732,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde_json",
- "spel-framework 0.1.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3413,7 +3761,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde",
- "spel-framework 0.1.0 (git+https://github.com/logos-co/spel.git?rev=e45857e)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3469,18 +3817,20 @@ dependencies = [
 [[package]]
 name = "nssa"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
+ "anyhow",
  "borsh",
  "hex",
+ "k256",
  "log",
  "nssa_core",
  "rand 0.8.5",
  "risc0-binfmt",
  "risc0-build",
  "risc0-zkvm",
- "secp256k1",
  "serde",
+ "serde_with",
  "sha2",
  "thiserror 2.0.18",
 ]
@@ -3488,11 +3838,12 @@ dependencies = [
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "base58",
  "borsh",
  "bytemuck",
+ "bytesize",
  "chacha20",
  "k256",
  "risc0-zkvm",
@@ -3910,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3920,6 +4271,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -4703,12 +5063,25 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4720,6 +5093,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 0.26.11",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4761,6 +5161,15 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "yaml-rust2",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4818,26 +5227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.9.2",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4868,6 +5257,31 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
+name = "sequencer_service_protocol"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
+dependencies = [
+ "common",
+ "nssa",
+ "nssa_core",
+]
+
+[[package]]
+name = "sequencer_service_rpc"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
+dependencies = [
+ "jsonrpsee",
+ "sequencer_service_protocol",
 ]
 
 [[package]]
@@ -5005,13 +5419,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5089,18 +5514,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+]
+
+[[package]]
 name = "spel"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?rev=e45857e#e45857e0e286cced50772e4d52354ef864f839a6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
 dependencies = [
  "base58",
  "borsh",
+ "common",
  "nssa",
  "nssa_core",
  "risc0-zkvm",
+ "sequencer_service_rpc",
  "serde",
  "serde_json",
- "spel-framework-core 0.1.0 (git+https://github.com/logos-co/spel.git?rev=e45857e)",
+ "spel-framework-core",
  "tokio",
  "wallet",
 ]
@@ -5108,42 +5550,18 @@ dependencies = [
 [[package]]
 name = "spel-framework"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#e45857e0e286cced50772e4d52354ef864f839a6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
 dependencies = [
  "borsh",
  "nssa_core",
- "spel-framework-core 0.1.0 (git+https://github.com/logos-co/spel.git?branch=main)",
- "spel-framework-macros 0.1.0 (git+https://github.com/logos-co/spel.git?branch=main)",
-]
-
-[[package]]
-name = "spel-framework"
-version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?rev=e45857e#e45857e0e286cced50772e4d52354ef864f839a6"
-dependencies = [
- "borsh",
- "nssa_core",
- "spel-framework-core 0.1.0 (git+https://github.com/logos-co/spel.git?rev=e45857e)",
- "spel-framework-macros 0.1.0 (git+https://github.com/logos-co/spel.git?rev=e45857e)",
+ "spel-framework-core",
+ "spel-framework-macros",
 ]
 
 [[package]]
 name = "spel-framework-core"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#e45857e0e286cced50772e4d52354ef864f839a6"
-dependencies = [
- "borsh",
- "nssa_core",
- "serde",
- "serde_json",
- "sha2",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spel-framework-core"
-version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?rev=e45857e#e45857e0e286cced50772e4d52354ef864f839a6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -5157,18 +5575,7 @@ dependencies = [
 [[package]]
 name = "spel-framework-macros"
 version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#e45857e0e286cced50772e4d52354ef864f839a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "spel-framework-macros"
-version = "0.1.0"
-source = "git+https://github.com/logos-co/spel.git?rev=e45857e#e45857e0e286cced50772e4d52354ef864f839a6"
+source = "git+https://github.com/jimmy-claw/spel.git?branch=jimmy%2Fupdate-lssa-latest#b64a2f36342cbb3ad2bbeeea901c14692a19dfc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5324,12 +5731,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+name = "testnet_initial_state"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
- "winapi-util",
+ "common",
+ "key_protocol",
+ "nssa",
+ "nssa_core",
+ "serde",
 ]
 
 [[package]]
@@ -5449,7 +5859,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -5524,6 +5934,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5919,7 +6330,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -5979,21 +6390,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/lssa.git?rev=767b5afd388c7981bcdf6f5b5c80159607e07e5b#767b5afd388c7981bcdf6f5b5c80159607e07e5b"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=ffcbc15972adbf557939bf3e2852af276422631b#ffcbc15972adbf557939bf3e2852af276422631b"
 dependencies = [
  "amm_core",
  "anyhow",
  "async-stream",
- "base64",
- "borsh",
- "bytemuck",
+ "ata_core",
+ "base58",
  "clap",
  "common",
  "env_logger",
  "futures",
  "hex",
+ "humantime",
+ "humantime-serde",
  "indicatif",
  "itertools 0.14.0",
  "key_protocol",
@@ -6002,9 +6424,12 @@ dependencies = [
  "nssa_core",
  "optfield",
  "rand 0.8.5",
+ "sequencer_service_rpc",
  "serde",
  "serde_json",
  "sha2",
+ "testnet_initial_state",
+ "thiserror 2.0.18",
  "token_core",
  "tokio",
  "url",
@@ -6166,6 +6591,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.6",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6277,9 +6720,27 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6300,6 +6761,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6337,6 +6813,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6349,6 +6831,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6358,6 +6846,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6385,6 +6879,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6394,6 +6894,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6409,6 +6915,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6418,6 +6930,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 [workspace.dependencies]
 risc0-zkvm = { version = "=3.0.5", features = ['std'] }
 risc0-build = "=3.0.5"
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
 borsh = "1.5.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,9 @@ generate-idl: ## Regenerate IDL from Rust annotations in lib.rs
 generate-ffi: ## Regenerate FFI client (multisig.rs) from IDL
 	@echo "🔨 Generating FFI client from $(IDL_JSON)..."
 	@mkdir -p /tmp/lez-ffi-gen
-	source ~/.cargo/env && lez-client-gen --idl $(IDL_JSON) --out-dir /tmp/lez-ffi-gen || \
-		(echo "ERROR: lez-client-gen not found. Run: make install-tools" && exit 1)
-	@# Prepend generated-file header, then append lez-client-gen output
+	source ~/.cargo/env && spel-client-gen --idl $(IDL_JSON) --out-dir /tmp/lez-ffi-gen || \
+		(echo "ERROR: spel-client-gen not found. Run: make install-tools" && exit 1)
+	@# Prepend generated-file header, then append spel-client-gen output
 	@echo "// GENERATED FILE — do not edit manually. Run 'make generate' to regenerate from Rust annotations." > $(FFI_RS)
 	@cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> $(FFI_RS)
 	@echo "✅ FFI client written to $(FFI_RS)"
@@ -90,7 +90,7 @@ help: ## Show this help
 	@echo "Multisig Program — Make Targets"
 	@echo ""
 	@echo "  Code Generation (start here after changing lib.rs):"
-	@echo "  make install-tools         Install lez-client-gen tool (first-time setup)"
+	@echo "  make install-tools         Install spel-client-gen tool (first-time setup)"
 	@echo "  make generate              Regen IDL + FFI client from lib.rs annotations"
 	@echo "  make generate-idl          Regen IDL only"
 	@echo "  make generate-ffi          Regen FFI client only (requires IDL)"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
+spel = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0" }
 tokio = { version = "1", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/logos-co/spel.git", rev = "e45857e" }
+spel = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
 tokio = { version = "1", features = ["full"] }

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -13,10 +13,10 @@ path = "tests/e2e_member_management.rs"
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-nssa = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b", features = ["host"] }
-common = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
-token_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+token_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 risc0-zkvm = "3.0"
 borsh = "1.5"
 tokio = { version = "1", features = ["full"] }

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -25,3 +25,6 @@ lez-multisig-ffi = { path = "../lez-multisig-ffi" }
 
 [lib]
 path = "src/lib.rs"
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+jsonrpsee-http-client = "0.24"
+hex = "0.4"

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -22,9 +22,10 @@ borsh = "1.5"
 tokio = { version = "1", features = ["full"] }
 
 lez-multisig-ffi = { path = "../lez-multisig-ffi" }
+hex = "0.4"
+jsonrpsee-http-client = "0.24"
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+
 
 [lib]
 path = "src/lib.rs"
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-jsonrpsee-http-client = "0.24"
-hex = "0.4"

--- a/e2e_tests/tests/e2e_member_management.rs
+++ b/e2e_tests/tests/e2e_member_management.rs
@@ -85,7 +85,7 @@ async fn submit_tx_expect_failure(client: &SequencerClient, tx: PublicTransactio
     }
 }
 
-async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> Nonce {
+async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
     client.get_account(account_id).await
         .map(|r| r.nonce.0)
         .unwrap_or(0)
@@ -130,7 +130,7 @@ async fn propose_approve_execute_config(
     let msg = Message::try_new(
         program_id,
         vec![multisig_state_id, proposer_id, proposal_pda],
-        vec![nonce],
+        vec![nssa_core::account::Nonce(nonce)],
         instruction,
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[proposer_key]);
@@ -144,7 +144,7 @@ async fn propose_approve_execute_config(
         let msg = Message::try_new(
             program_id,
             vec![multisig_state_id, approver_id, proposal_pda],
-            vec![nonce],
+            vec![nssa_core::account::Nonce(nonce)],
             Instruction::Approve { create_key: *create_key, proposal_index },
         ).unwrap();
         let ws = WitnessSet::for_message(&msg, &[approver_key]);
@@ -158,7 +158,7 @@ async fn propose_approve_execute_config(
     let msg = Message::try_new(
         program_id,
         vec![multisig_state_id, executor_id, proposal_pda],
-        vec![nonce],
+        vec![nssa_core::account::Nonce(nonce)],
         Instruction::Execute { create_key: *create_key, proposal_index },
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[proposer_key]);
@@ -277,7 +277,7 @@ async fn test_member_management() {
     let msg = Message::try_new(
         program_id,
         vec![multisig_state_id, m1, proposal_pda],
-        vec![nonce],
+        vec![nssa_core::account::Nonce(nonce)],
         Instruction::ProposeRemoveMember { member: *m3.value(), create_key, proposal_index: 4 },
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[&key1]);
@@ -290,7 +290,7 @@ async fn test_member_management() {
         let msg = Message::try_new(
             program_id,
             vec![multisig_state_id, id, proposal_pda],
-            vec![nonce],
+            vec![nssa_core::account::Nonce(nonce)],
             Instruction::Approve { create_key, proposal_index: 4 },
         ).unwrap();
         let ws = WitnessSet::for_message(&msg, &[key]);
@@ -303,7 +303,7 @@ async fn test_member_management() {
     let msg = Message::try_new(
         program_id,
         vec![multisig_state_id, m1, proposal_pda],
-        vec![nonce],
+        vec![nssa_core::account::Nonce(nonce)],
         Instruction::Execute { create_key, proposal_index: 4 },
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[&key1]);

--- a/e2e_tests/tests/e2e_member_management.rs
+++ b/e2e_tests/tests/e2e_member_management.rs
@@ -85,9 +85,9 @@ async fn submit_tx_expect_failure(client: &SequencerClient, tx: PublicTransactio
     }
 }
 
-async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
+async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> Nonce {
     client.get_account(account_id).await
-        .map(|r| r.nonce)
+        .map(|r| r.nonce.0)
         .unwrap_or(0)
 }
 

--- a/e2e_tests/tests/e2e_member_management.rs
+++ b/e2e_tests/tests/e2e_member_management.rs
@@ -17,7 +17,8 @@ use nssa::{
 };
 use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{compute_multisig_state_pda, compute_proposal_pda};
-use common::sequencer_client::SequencerClient;
+use sequencer_service_rpc::{SequencerClient, SequencerClientBuilder, RpcClient as _};
+use common::transaction::NSSATransaction;
 
 const BLOCK_WAIT_SECS: u64 = 15;
 
@@ -29,13 +30,13 @@ fn account_id_from_key(key: &PrivateKey) -> AccountId {
 fn sequencer_client() -> SequencerClient {
     let url = std::env::var("SEQUENCER_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:3040".to_string());
-    SequencerClient::new(url.parse().unwrap()).expect("Failed to create sequencer client")
+    SequencerClientBuilder::default().build(&url).expect("Failed to create sequencer client")
 }
 
 async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
-    let response = client.send_tx_public(tx).await.expect("Failed to submit tx");
-    let tx_hash = response.tx_hash.clone();
-    println!("  tx_hash: {}", tx_hash);
+    let response = client.send_transaction(NSSATransaction::Public(tx)).await.expect("Failed to submit tx");
+    let tx_hash = response;
+    println!("  tx_hash: {}", hex::encode(tx_hash.0));
 
     let max_wait = Duration::from_secs(BLOCK_WAIT_SECS * 3);
     let poll_interval = Duration::from_secs(3);
@@ -43,14 +44,14 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
 
     loop {
         tokio::time::sleep(poll_interval).await;
-        match client.get_transaction_by_hash(tx_hash.clone()).await {
-            Ok(resp) if resp.transaction.is_some() => {
+        match client.get_transaction(tx_hash.clone()).await {
+            Ok(resp) if resp.is_some() => {
                 println!("  ✅ tx included in block");
                 return;
             }
             _ => {
                 if start.elapsed() > max_wait {
-                    panic!("❌ Transaction {} not included after {:?}", tx_hash, max_wait);
+                    panic!("❌ Transaction {} not included after {:?}", hex::encode(tx_hash.0), max_wait);
                 }
             }
         }
@@ -60,18 +61,18 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
 /// Submit a tx that we expect to fail (not get included).
 /// Returns true if it was correctly rejected/not included.
 async fn submit_tx_expect_failure(client: &SequencerClient, tx: PublicTransaction) -> bool {
-    match client.send_tx_public(tx).await {
+    match client.send_transaction(NSSATransaction::Public(tx)).await {
         Err(_) => {
             println!("  ✅ Transaction rejected at submission (expected)");
             return true;
         }
         Ok(response) => {
-            let tx_hash = response.tx_hash.clone();
-            println!("  tx_hash: {} (expecting non-inclusion)", tx_hash);
+            let tx_hash = response;
+            println!("  tx_hash: {} (expecting non-inclusion)", hex::encode(tx_hash.0));
             // Wait a bit and check it wasn't included
             tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS * 2)).await;
-            match client.get_transaction_by_hash(tx_hash.clone()).await {
-                Ok(resp) if resp.transaction.is_some() => {
+            match client.get_transaction(tx_hash.clone()).await {
+                Ok(resp) if resp.is_some() => {
                     println!("  ❌ Transaction was unexpectedly included!");
                     false
                 }
@@ -86,19 +87,19 @@ async fn submit_tx_expect_failure(client: &SequencerClient, tx: PublicTransactio
 
 async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
     client.get_account(account_id).await
-        .map(|r| r.account.nonce)
+        .map(|r| r.nonce)
         .unwrap_or(0)
 }
 
 async fn get_multisig_state(client: &SequencerClient, state_id: AccountId) -> MultisigState {
     let account = client.get_account(state_id).await.expect("Failed to get multisig state");
-    let data: Vec<u8> = account.account.data.into();
+    let data: Vec<u8> = account.data.into();
     borsh::from_slice(&data).expect("Failed to deserialize multisig state")
 }
 
 async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Proposal {
     let account = client.get_account(proposal_id).await.expect("Failed to get proposal");
-    let data: Vec<u8> = account.account.data.into();
+    let data: Vec<u8> = account.data.into();
     borsh::from_slice(&data).expect("Failed to deserialize proposal")
 }
 
@@ -184,7 +185,7 @@ async fn test_member_management() {
 
     match client.send_tx_program(deploy_tx).await {
         Ok(r) => {
-            println!("  Deployed: {}", r.tx_hash);
+            println!("  Deployed: {}", hex::encode(r.0));
             tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;
         }
         Err(e) => println!("  Deploy skipped (already deployed): {}", e),

--- a/e2e_tests/tests/e2e_member_management.rs
+++ b/e2e_tests/tests/e2e_member_management.rs
@@ -183,7 +183,7 @@ async fn test_member_management() {
         .unwrap_or_else(|_| panic!("Cannot read multisig binary at '{}'", multisig_path));
     let (deploy_tx, program_id) = deploy_program(multisig_bytecode);
 
-    match client.send_tx_program(deploy_tx).await {
+    match client.send_transaction(NSSATransaction::ProgramDeployment(deploy_tx)).await {
         Ok(r) => {
             println!("  Deployed: {}", hex::encode(r.0));
             tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -24,7 +24,6 @@ use nssa::{
     public_transaction::{Message, WitnessSet},
 };
 use nssa_core::program::PdaSeed;
-use nssa_core::account::Nonce;
 use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{
     compute_multisig_state_pda, compute_proposal_pda, compute_vault_pda, vault_pda_seed_bytes,
@@ -76,7 +75,7 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
     }
 }
 
-async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> Nonce {
+async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
     client.get_account(account_id).await
         .map(|r| r.nonce.0)
         .unwrap_or(0)
@@ -102,7 +101,7 @@ async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Propo
     let account = client.get_account(proposal_id).await.expect("Failed to get proposal");
     println!("  [DEBUG] Proposal account program_owner: {:?}", account.program_owner);
     println!("  [DEBUG] Proposal account balance: {}", account.balance);
-    println!("  [DEBUG] Proposal account nonce: {}", account.nonce);
+    println!("  [DEBUG] Proposal account nonce: {}", account.nonce.0);
     let data: Vec<u8> = account.data.into();
     println!("  [DEBUG] Proposal raw data length: {} bytes", data.len());
     if data.len() >= 128 {
@@ -248,7 +247,7 @@ async fn test_multisig_token_transfer() {
     let msg = Message::try_new(
         token_program_id,
         vec![minter_holding_id, vault_id],
-        vec![nonce],
+        vec![nssa_core::account::Nonce(nonce)],
         transfer_to_vault,
     ).unwrap();
     // Sign with minter_holding_key (the key that derives to the sender account)

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -75,9 +75,9 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
     }
 }
 
-async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
+async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> Nonce {
     client.get_account(account_id).await
-        .map(|r| r.nonce)
+        .map(|r| r.nonce.0)
         .unwrap_or(0)
 }
 

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -24,6 +24,7 @@ use nssa::{
     public_transaction::{Message, WitnessSet},
 };
 use nssa_core::program::PdaSeed;
+use nssa_core::account::Nonce;
 use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{
     compute_multisig_state_pda, compute_proposal_pda, compute_vault_pda, vault_pda_seed_bytes,
@@ -99,8 +100,8 @@ async fn get_multisig_state(client: &SequencerClient, state_id: AccountId) -> Mu
 
 async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Proposal {
     let account = client.get_account(proposal_id).await.expect("Failed to get proposal");
-    println!("  [DEBUG] Proposal account program_owner: {:?}", account.account.program_owner);
-    println!("  [DEBUG] Proposal account balance: {}", account.account.balance);
+    println!("  [DEBUG] Proposal account program_owner: {:?}", account.program_owner);
+    println!("  [DEBUG] Proposal account balance: {}", account.balance);
     println!("  [DEBUG] Proposal account nonce: {}", account.nonce);
     let data: Vec<u8> = account.data.into();
     println!("  [DEBUG] Proposal raw data length: {} bytes", data.len());
@@ -163,7 +164,7 @@ async fn test_multisig_token_transfer() {
 
     // Deploy both (skip if already deployed)
     for (name, tx) in [("token", token_deploy_tx), ("multisig", multisig_deploy_tx)] {
-        match client.send_tx_program(tx).await {
+        match client.send_transaction(NSSATransaction::ProgramDeployment(tx)).await {
             Ok(r) => {
                 println!("  {} deployed: {}", name, hex::encode(r.0));
                 tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -23,7 +23,6 @@ use nssa::{
     program::Program,
     public_transaction::{Message, WitnessSet},
 };
-use nssa_core::program::PdaSeed;
 use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{
     compute_multisig_state_pda, compute_proposal_pda, compute_vault_pda, vault_pda_seed_bytes,
@@ -290,7 +289,7 @@ async fn test_multisig_token_transfer() {
     let msg = Message::try_new(
         multisig_program_id,
         vec![multisig_state_id, m1, proposal_id], // Propose expects 3 accounts now
-        vec![nonce_m1], // Only signer nonces
+        vec![nssa_core::account::Nonce(nonce_m1)], // Only signer nonces
         propose_instruction,
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[&key1]);
@@ -313,7 +312,7 @@ async fn test_multisig_token_transfer() {
     let msg = Message::try_new(
         multisig_program_id,
         vec![multisig_state_id, m2, proposal_id], // Approve expects 3 accounts now
-        vec![nonce_m2], // Only signer nonces
+        vec![nssa_core::account::Nonce(nonce_m2)], // Only signer nonces
         Instruction::Approve { create_key, proposal_index: 1 },
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[&key2]);
@@ -335,7 +334,7 @@ async fn test_multisig_token_transfer() {
     let msg = Message::try_new(
         multisig_program_id,
         vec![multisig_state_id, m1, proposal_id, vault_id, recipient_id],
-        vec![nonce_m1], // Only signer nonces
+        vec![nssa_core::account::Nonce(nonce_m1)], // Only signer nonces
         Instruction::Execute { create_key, proposal_index: 1 },
     ).unwrap();
     let ws = WitnessSet::for_message(&msg, &[&key1]);

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -28,7 +28,8 @@ use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{
     compute_multisig_state_pda, compute_proposal_pda, compute_vault_pda, vault_pda_seed_bytes,
 };
-use common::sequencer_client::SequencerClient;
+use sequencer_service_rpc::{SequencerClient, SequencerClientBuilder, RpcClient as _};
+use common::transaction::NSSATransaction;
 use token_core::{Instruction as TokenInstruction, TokenHolding};
 
 const BLOCK_WAIT_SECS: u64 = 15;
@@ -41,13 +42,13 @@ fn account_id_from_key(key: &PrivateKey) -> AccountId {
 fn sequencer_client() -> SequencerClient {
     let url = std::env::var("SEQUENCER_URL")
         .unwrap_or_else(|_| "http://127.0.0.1:3040".to_string());
-    SequencerClient::new(url.parse().unwrap()).expect("Failed to create sequencer client")
+    SequencerClientBuilder::default().build(&url).expect("Failed to create sequencer client")
 }
 
 async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
-    let response = client.send_tx_public(tx).await.expect("Failed to submit tx");
-    let tx_hash = response.tx_hash.clone();
-    println!("  tx_hash: {}", tx_hash);
+    let response = client.send_transaction(NSSATransaction::Public(tx)).await.expect("Failed to submit tx");
+    let tx_hash = response;
+    println!("  tx_hash: {}", hex::encode(tx_hash.0));
 
     // Wait for inclusion: poll for up to 2 block periods
     let max_wait = Duration::from_secs(BLOCK_WAIT_SECS * 3);
@@ -57,8 +58,8 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
     loop {
         tokio::time::sleep(poll_interval).await;
 
-        match client.get_transaction_by_hash(tx_hash.clone()).await {
-            Ok(resp) if resp.transaction.is_some() => {
+        match client.get_transaction(tx_hash.clone()).await {
+            Ok(resp) if resp.is_some() => {
                 println!("  ✅ tx included in block");
                 return;
             }
@@ -76,13 +77,13 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
 
 async fn get_nonce(client: &SequencerClient, account_id: AccountId) -> u128 {
     client.get_account(account_id).await
-        .map(|r| r.account.nonce)
+        .map(|r| r.nonce)
         .unwrap_or(0)
 }
 
 async fn get_balance(client: &SequencerClient, account_id: AccountId) -> Option<u128> {
     let resp = client.get_account(account_id).await.ok()?;
-    let data: Vec<u8> = resp.account.data.into();
+    let data: Vec<u8> = resp.data.into();
     let holding: TokenHolding = borsh::from_slice(&data).ok()?;
     match holding {
         TokenHolding::Fungible { balance, .. } => Some(balance),
@@ -92,7 +93,7 @@ async fn get_balance(client: &SequencerClient, account_id: AccountId) -> Option<
 
 async fn get_multisig_state(client: &SequencerClient, state_id: AccountId) -> MultisigState {
     let account = client.get_account(state_id).await.expect("Failed to get multisig state");
-    let data: Vec<u8> = account.account.data.into();
+    let data: Vec<u8> = account.data.into();
     borsh::from_slice(&data).expect("Failed to deserialize multisig state")
 }
 
@@ -100,8 +101,8 @@ async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Propo
     let account = client.get_account(proposal_id).await.expect("Failed to get proposal");
     println!("  [DEBUG] Proposal account program_owner: {:?}", account.account.program_owner);
     println!("  [DEBUG] Proposal account balance: {}", account.account.balance);
-    println!("  [DEBUG] Proposal account nonce: {}", account.account.nonce);
-    let data: Vec<u8> = account.account.data.into();
+    println!("  [DEBUG] Proposal account nonce: {}", account.nonce);
+    let data: Vec<u8> = account.data.into();
     println!("  [DEBUG] Proposal raw data length: {} bytes", data.len());
     if data.len() >= 128 {
         println!("  [DEBUG] Proposal raw data (first 128 bytes): {:02x?}", &data[..128]);
@@ -164,7 +165,7 @@ async fn test_multisig_token_transfer() {
     for (name, tx) in [("token", token_deploy_tx), ("multisig", multisig_deploy_tx)] {
         match client.send_tx_program(tx).await {
             Ok(r) => {
-                println!("  {} deployed: {}", name, r.tx_hash);
+                println!("  {} deployed: {}", name, hex::encode(r.0));
                 tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;
             }
             Err(e) => println!("  {} deploy skipped: {}", name, e),

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0" }
 serde_json = "1"

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "e45857e" }
+spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
 serde_json = "1"

--- a/lez-multisig-ffi/Cargo.toml
+++ b/lez-multisig-ffi/Cargo.toml
@@ -18,9 +18,10 @@ hex = "0.4"
 bs58 = "0.5"
 
 # nssa deps for transaction building
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b", features = ["host"] }
-nssa = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
-common = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
-wallet = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 borsh = "1.5"
 sha2 = "0.10"
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }

--- a/lez-multisig-ffi/src/lib.rs
+++ b/lez-multisig-ffi/src/lib.rs
@@ -8,7 +8,25 @@
 mod multisig;
 
 // Re-export generated PDA compute helpers for use by tests and other crates.
-pub use multisig::{compute_multisig_state_pda, compute_proposal_pda};
+fn _compute_pda(seeds: &[&[u8]]) -> nssa_core::account::AccountId {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    for seed in seeds {
+        let mut padded = [0u8; 32];
+        let len = seed.len().min(32);
+        padded[..len].copy_from_slice(&seed[..len]);
+        hasher.update(&padded);
+    }
+    nssa_core::account::AccountId::new(hasher.finalize().into())
+}
+
+pub fn compute_multisig_state_pda(_program_id: &nssa_core::program::ProgramId, create_key: &[u8; 32]) -> nssa_core::account::AccountId {
+    _compute_pda(&[create_key as &[u8]])
+}
+
+pub fn compute_proposal_pda(_program_id: &nssa_core::program::ProgramId, create_key: &[u8; 32], proposal_index: u64) -> nssa_core::account::AccountId {
+    _compute_pda(&[b"multisig_prop___", create_key as &[u8], &proposal_index.to_le_bytes()])
+}
 
 // Vault PDA helpers — derived from program_id + create_key
 // Seeds: SHA256(pad("multisig_vault___") || create_key)

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0" }
 serde_json = "1"

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
 serde_json = "1"

--- a/methods/guest/src/bin/multisig.rs
+++ b/methods/guest/src/bin/multisig.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use nssa_core::program::{ProgramInput, read_nssa_inputs, write_nssa_outputs_with_chained_call};
+use nssa_core::program::{ProgramInput, ProgramOutput, read_nssa_inputs};
 use multisig_core::Instruction;
 
 risc0_zkvm::guest::entry!(main);
@@ -13,10 +13,11 @@ fn main() {
 
     let (post_states, chained_calls) = multisig_program::process(&pre_states, &instruction);
 
-    write_nssa_outputs_with_chained_call(
+    ProgramOutput::new(
         instruction_words,
         pre_states_clone,
         post_states,
-        chained_calls,
-    );
+    )
+    .with_chained_calls(chained_calls)
+    .write();
 }

--- a/multisig_core/Cargo.toml
+++ b/multisig_core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh = "1.5.7"
 sha2 = { version = "0.10", default-features = false }

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "e45857e" }
+spel-framework = { git = "https://github.com/jimmy-claw/spel.git", branch = "jimmy/update-lssa-latest" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true


### PR DESCRIPTION
## Summary
Updates all dependencies to latest LEZ (logos-execution-zone) and SPEL framework.

## Changes
- **LEZ deps**: `logos-blockchain/lssa` → `logos-blockchain/logos-execution-zone` at `ffcbc159`
- **SPEL deps**: pointed at `jimmy-claw/spel` branch `jimmy/update-lssa-latest` (logos-co/spel PR #90) — will update to SPEL main rev once #90 merges
- **Guest binary**: `write_nssa_outputs_with_chained_call` → `ProgramOutput::new().with_chained_calls().write()`
- **FFI crate**: added `sequencer_service_rpc` for new RPC trait, `send_tx_public` → `send_transaction`
- **E2E CI**: `sequencer_runner` → `sequencer_service`, updated config paths, SHA-based clone

## Depends on
- https://github.com/logos-co/spel/pull/90 (SPEL LEZ update)