### PR TITLE
chore: update SPEL to v0.2.0-rc.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
           # Fix type inference issues in generated code (spel-client-gen omits some annotations)
           sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'let create_key: \[u8; 32\] = serde_json::from_value' lez-multisig-ffi/src/multisig.rs || \
+            (echo "ERROR: type annotation patch for create_key did not apply — spel-client-gen output may have changed" && exit 1)
           echo "✅ FFI client generated"
 
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # Fix type inference issues in generated code (spel-client-gen omits some annotations)
+          sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
           echo "✅ FFI client generated"
 
       - name: Run unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SPEL_REF: "main"
 
 jobs:
   check:
@@ -29,9 +28,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'spel-framework.*tag = ' lez-multisig-ffi/Cargo.toml | sed 's/.*tag = "\([^"]*\)".*/\1/')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
           # Fix type inference issues in generated code (spel-client-gen omits some annotations)
           sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'let create_key: \[u8; 32\] = serde_json::from_value' lez-multisig-ffi/src/multisig.rs || \
+            (echo "ERROR: type annotation patch for create_key did not apply — spel-client-gen output may have changed" && exit 1)
 
       - name: Run unit tests
         env:
@@ -117,6 +119,8 @@ jobs:
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
           # Fix type inference issues in generated code (spel-client-gen omits some annotations)
           sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'let create_key: \[u8; 32\] = serde_json::from_value' lez-multisig-ffi/src/multisig.rs || \
+            (echo "ERROR: type annotation patch for create_key did not apply — spel-client-gen output may have changed" && exit 1)
 
       - name: Cache guest binary
         id: cache-guest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -112,6 +112,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # Fix type inference issues in generated code (spel-client-gen omits some annotations)
+          sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
 
       - name: Cache guest binary
         id: cache-guest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # Fix type inference issues in generated code (spel-client-gen omits some annotations)
+          sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' lez-multisig-ffi/src/multisig.rs
 
       - name: Run unit tests
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,6 @@ env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
   LSSA_REF: "v0.2.0-rc1"
-  SPEL_REF: "main"
 
 jobs:
   unit-tests:
@@ -30,9 +29,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'spel-framework.*tag = ' lez-multisig-ffi/Cargo.toml | sed 's/.*tag = "\([^"]*\)".*/\1/')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 
@@ -101,9 +101,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'spel-framework.*tag = ' lez-multisig-ffi/Cargo.toml | sed 's/.*tag = "\([^"]*\)".*/\1/')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -6,7 +6,7 @@ on:
       spel_ref:
         description: 'SPEL branch, tag, commit SHA, or refs/pull/123/head for PRs'
         required: true
-        default: 'main'
+        default: 'v0.2.0-rc.5'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,7 +2965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework-core",
  "tokio",
  "wallet",
 ]
@@ -2976,7 +2976,7 @@ version = "0.1.0"
 dependencies = [
  "multisig_program",
  "serde_json",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3747,7 +3747,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde_json",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3775,7 +3775,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -5540,7 +5540,7 @@ dependencies = [
 [[package]]
 name = "spel"
 version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.5#ed3bbedb4b684645da05455d30a4a0be7cc4dfe0"
 dependencies = [
  "base58",
  "borsh",
@@ -5552,37 +5552,28 @@ dependencies = [
  "sequencer_service_rpc",
  "serde",
  "serde_json",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework-core",
  "tokio",
+ "toml",
  "wallet",
 ]
 
 [[package]]
 name = "spel-framework"
 version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.5#ed3bbedb4b684645da05455d30a4a0be7cc4dfe0"
 dependencies = [
  "borsh",
  "nssa_core",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
- "spel-framework-macros 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
-]
-
-[[package]]
-name = "spel-framework"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
-dependencies = [
- "borsh",
- "nssa_core",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
- "spel-framework-macros 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
+ "serde_json",
+ "spel-framework-core",
+ "spel-framework-macros",
 ]
 
 [[package]]
 name = "spel-framework-core"
 version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.5#ed3bbedb4b684645da05455d30a4a0be7cc4dfe0"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -5594,37 +5585,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "spel-framework-core"
+name = "spel-framework-macros"
 version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.2.0-rc.5#ed3bbedb4b684645da05455d30a4a0be7cc4dfe0"
 dependencies = [
- "borsh",
- "nssa_core",
- "serde",
+ "proc-macro2",
+ "quote",
  "serde_json",
  "sha2",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spel-framework-macros"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "spel-framework-macros"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
+ "spel-framework-core",
  "syn 2.0.117",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endef
 # Pipeline: lib.rs → multisig_idl.json → multisig.rs
 
 SPEL_FW_GIT  := https://github.com/logos-co/spel.git
-SPEL_FW_BRANCH := main
+SPEL_FW_TAG  := $(shell grep -m1 'spel-framework.*tag = ' lez-multisig-ffi/Cargo.toml | sed 's/.*tag = "\([^"]*\)".*/\1/')
 IDL_JSON    := lez-multisig-ffi/src/multisig_idl.json
 FFI_RS      := lez-multisig-ffi/src/multisig.rs
 GENERATE_IDL_BIN := methods/guest/Cargo.toml
@@ -53,8 +53,8 @@ GENERATE_IDL_BIN := methods/guest/Cargo.toml
 .PHONY: generate generate-idl generate-ffi check-generated install-tools
 
 install-tools: ## Install spel-client-gen from spel framework (required for generate-ffi)
-	source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --branch $(SPEL_FW_BRANCH) spel-client-gen --locked 2>/dev/null || \
-	cargo install --git $(SPEL_FW_GIT) --branch $(SPEL_FW_BRANCH) spel-client-gen
+	source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen --locked 2>/dev/null || \
+	cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen
 
 generate-idl: ## Regenerate IDL from Rust annotations in lib.rs
 	@echo "🔨 Generating IDL from multisig_program/src/lib.rs..."
@@ -69,6 +69,8 @@ generate-ffi: ## Regenerate FFI client (multisig.rs) from IDL
 	@# Prepend generated-file header, then append spel-client-gen output
 	@echo "// GENERATED FILE — do not edit manually. Run 'make generate' to regenerate from Rust annotations." > $(FFI_RS)
 	@cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> $(FFI_RS)
+	@# Fix type inference gap in generated code (spel-client-gen omits [u8; 32] annotation on create_key)
+	@sed -i 's/let create_key = serde_json::from_value/let create_key: [u8; 32] = serde_json::from_value/g' $(FFI_RS)
 	@echo "✅ FFI client written to $(FFI_RS)"
 
 generate: ## Regenerate IDL and FFI client from Rust annotations (run after changing lib.rs)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.5" }
 tokio = { version = "1", features = ["full"] }

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.5" }
 serde_json = "1"

--- a/lez-multisig-ffi/Cargo.toml
+++ b/lez-multisig-ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-spel-framework-core = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.5" }
 serde_json = "1"

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.5" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true


### PR DESCRIPTION
Closes https://github.com/logos-co/lez-multisig/issues/33

## What

Updated all SPEL dependencies from `branch = "main"` to `tag = "v0.2.0-rc.5"`:

- cli/Cargo.toml — spel
- idl-gen/Cargo.toml — spel-framework
- lez-multisig-ffi/Cargo.toml — spel-framework-core
- methods/guest/Cargo.toml — spel-framework
- multisig_program/Cargo.toml — spel-framework

## Notes

- nssa_core deps remain at v0.2.0-rc1 (spel-framework rc.5 pins it there; mixing versions causes type incompatibility)
- All 28 unit tests pass in multisig_program
- lez-multisig-ffi has pre-existing missing files (multisig.rs, multisig_idl.json) unrelated to this update