### PR TITLE
chore: update SPEL to v0.3.0 and nssa to v0.2.0-rc3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SPEL_REF: "main"
 
 jobs:
   check:
@@ -29,9 +28,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+          # Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
           sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
           grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
           echo "✅ FFI client generated"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
           echo "✅ FFI client generated"
 
       - name: Run unit tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,6 +115,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 
       - name: Cache guest binary
         id: cache-guest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,8 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc1"
-  SPEL_REF: "main"
+  LSSA_REF: "v0.2.0-rc3"
 
 jobs:
   unit-tests:
@@ -30,9 +29,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 
@@ -99,9 +99,10 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           cargo install \
             --git https://github.com/logos-co/spel.git \
-            --branch ${{ env.SPEL_REF }} \
+            --tag "$SPEL_TAG" \
             spel-client-gen \
             --locked
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+          # Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
           sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
           grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 
@@ -115,6 +117,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+          # Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
           sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
           grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,8 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 
       - name: Run unit tests
         env:

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -99,6 +99,10 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+          # Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
+          sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 
       - name: Run unit tests
         env:
@@ -210,6 +214,10 @@ jobs:
           spel-client-gen --idl lez-multisig-ffi/src/multisig_idl.json --out-dir /tmp/lez-ffi-gen
           echo '// GENERATED FILE — do not edit manually. Run make generate to regenerate.' > lez-multisig-ffi/src/multisig.rs
           cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> lez-multisig-ffi/src/multisig.rs
+          # spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+          # Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
+          sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' lez-multisig-ffi/src/multisig.rs
+          grep -q 'create_key: \[u8; 32\]' lez-multisig-ffi/src/multisig.rs || (echo "ERROR: create_key type patch did not apply" && exit 1)
 
       - name: Cache guest binary
         id: cache-guest

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -6,12 +6,12 @@ on:
       spel_ref:
         description: 'SPEL branch, tag, commit SHA, or refs/pull/123/head for PRs'
         required: true
-        default: 'main'
+        default: 'v0.3.0'
 
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc1"
+  LSSA_REF: "v0.2.0-rc3"
 
 jobs:
   unit-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "ata_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "nssa_core",
  "risc0-zkvm",
@@ -1071,7 +1071,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "anyhow",
  "base64",
@@ -2875,7 +2875,7 @@ dependencies = [
 [[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2965,7 +2965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework-core",
  "tokio",
  "wallet",
 ]
@@ -2976,7 +2976,7 @@ version = "0.1.0"
 dependencies = [
  "multisig_program",
  "serde_json",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3056,7 +3056,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 [[package]]
 name = "logos-blockchain-blend-crypto"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-message"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "blake2",
  "derivative",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-blend-proofs"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "ed25519-dalek",
  "generic-array 1.3.5",
@@ -3112,7 +3112,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "derivative",
@@ -3128,7 +3128,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-chain-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-prover"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "logos-blockchain-circuits-utils",
  "tempfile",
@@ -3168,7 +3168,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-circuits-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "dirs",
 ]
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-common-http-client"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "futures",
  "hex",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-core"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "ark-ff 0.4.2",
  "bincode",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "cfg_eval",
  "logos-blockchain-pol",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "bytes",
  "futures",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-groth16"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ec 0.4.2",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-http-api-common"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "axum",
  "logos-blockchain-core",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3318,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-ledger"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-network-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3370,7 +3370,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poc"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-pol"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "astro-float",
  "logos-blockchain-circuits-prover",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poq"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-poseidon2"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
@@ -3433,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-services-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3448,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-storage-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-time-service"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3485,7 +3485,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-tracing"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utils"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "async-trait",
  "blake2",
@@ -3525,7 +3525,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-utxotree"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "ark-ff 0.4.2",
  "logos-blockchain-groth16",
@@ -3539,7 +3539,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-witness-generator"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "tempfile",
 ]
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "logos-blockchain-zksign"
 version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git#1dca38a294682259b6f1d47805aa3e38d05808f3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
 dependencies = [
  "logos-blockchain-circuits-prover",
  "logos-blockchain-circuits-utils",
@@ -3747,7 +3747,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde_json",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3775,7 +3775,7 @@ dependencies = [
  "nssa_core",
  "risc0-zkvm",
  "serde",
- "spel-framework 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework",
 ]
 
 [[package]]
@@ -3831,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "nssa"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3853,7 +3853,7 @@ dependencies = [
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "base58",
  "borsh",
@@ -5277,7 +5277,7 @@ checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 [[package]]
 name = "sequencer_service_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "common",
  "nssa",
@@ -5287,7 +5287,7 @@ dependencies = [
 [[package]]
 name = "sequencer_service_rpc"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "jsonrpsee",
  "sequencer_service_protocol",
@@ -5539,8 +5539,8 @@ dependencies = [
 
 [[package]]
 name = "spel"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+version = "0.3.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.3.0#ea07765e4291bd253e1de267ddb1cde0e38062d3"
 dependencies = [
  "base58",
  "borsh",
@@ -5552,40 +5552,32 @@ dependencies = [
  "sequencer_service_rpc",
  "serde",
  "serde_json",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
+ "spel-framework-core",
  "tokio",
+ "toml",
  "wallet",
 ]
 
 [[package]]
 name = "spel-framework"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+version = "0.3.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.3.0#ea07765e4291bd253e1de267ddb1cde0e38062d3"
 dependencies = [
  "borsh",
  "nssa_core",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
- "spel-framework-macros 0.2.0 (git+https://github.com/logos-co/spel.git?branch=main)",
-]
-
-[[package]]
-name = "spel-framework"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
-dependencies = [
- "borsh",
- "nssa_core",
- "spel-framework-core 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
- "spel-framework-macros 0.2.0 (git+https://github.com/logos-co/spel.git?branch=pr-126)",
+ "serde_json",
+ "spel-framework-core",
+ "spel-framework-macros",
 ]
 
 [[package]]
 name = "spel-framework-core"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
+version = "0.3.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.3.0#ea07765e4291bd253e1de267ddb1cde0e38062d3"
 dependencies = [
  "borsh",
  "nssa_core",
+ "proc-macro2",
  "serde",
  "serde_json",
  "sha2",
@@ -5594,37 +5586,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "spel-framework-core"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
+name = "spel-framework-macros"
+version = "0.3.0"
+source = "git+https://github.com/logos-co/spel.git?tag=v0.3.0#ea07765e4291bd253e1de267ddb1cde0e38062d3"
 dependencies = [
- "borsh",
- "nssa_core",
- "serde",
+ "proc-macro2",
+ "quote",
  "serde_json",
  "sha2",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "spel-framework-macros"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=main#238488147a7084fff83b88882a1ca8e9be522764"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "spel-framework-macros"
-version = "0.2.0"
-source = "git+https://github.com/logos-co/spel.git?branch=pr-126#2e8af264e49eea8b042540c921b7bf736c7ef3c3"
-dependencies = [
- "proc-macro2",
- "quote",
- "sha2",
+ "spel-framework-core",
  "syn 2.0.117",
 ]
 
@@ -5778,7 +5748,7 @@ dependencies = [
 [[package]]
 name = "testnet_initial_state"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "common",
  "key_protocol",
@@ -5904,7 +5874,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -6447,7 +6417,7 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc1#35d8df0d031315219f94d1546ceb862b0e5b208f"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "amm_core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 [workspace.dependencies]
 risc0-zkvm = { version = "=3.0.5", features = ['std'] }
 risc0-build = "=3.0.5"
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
 borsh = "1.5.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ generate-ffi: ## Regenerate FFI client (multisig.rs) from IDL
 	@# Prepend generated-file header, then append spel-client-gen output
 	@echo "// GENERATED FILE — do not edit manually. Run 'make generate' to regenerate from Rust annotations." > $(FFI_RS)
 	@cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> $(FFI_RS)
+	@# spel-client-gen omits the [u8; 32] type on create_key; Rust can't infer it from .as_ref() alone (E0282).
+	@# Remove once upstream fixes: https://github.com/logos-co/spel/issues/200
 	@sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' $(FFI_RS)
 	@grep -q 'create_key: \[u8; 32\]' $(FFI_RS) || (echo "ERROR: create_key type patch did not apply" && exit 1)
 	@echo "✅ FFI client written to $(FFI_RS)"

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endef
 # Pipeline: lib.rs → multisig_idl.json → multisig.rs
 
 SPEL_FW_GIT  := https://github.com/logos-co/spel.git
-SPEL_FW_BRANCH := main
+SPEL_FW_TAG  := $(shell grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
 IDL_JSON    := lez-multisig-ffi/src/multisig_idl.json
 FFI_RS      := lez-multisig-ffi/src/multisig.rs
 GENERATE_IDL_BIN := methods/guest/Cargo.toml
@@ -53,8 +53,8 @@ GENERATE_IDL_BIN := methods/guest/Cargo.toml
 .PHONY: generate generate-idl generate-ffi check-generated install-tools
 
 install-tools: ## Install spel-client-gen from spel framework (required for generate-ffi)
-	source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --branch $(SPEL_FW_BRANCH) spel-client-gen --locked 2>/dev/null || \
-	cargo install --git $(SPEL_FW_GIT) --branch $(SPEL_FW_BRANCH) spel-client-gen
+	source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen --locked 2>/dev/null || \
+	cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen
 
 generate-idl: ## Regenerate IDL from Rust annotations in lib.rs
 	@echo "🔨 Generating IDL from multisig_program/src/lib.rs..."

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ generate-ffi: ## Regenerate FFI client (multisig.rs) from IDL
 	@# Prepend generated-file header, then append spel-client-gen output
 	@echo "// GENERATED FILE — do not edit manually. Run 'make generate' to regenerate from Rust annotations." > $(FFI_RS)
 	@cat /tmp/lez-ffi-gen/multisig_program_ffi.rs >> $(FFI_RS)
+	@sed -i 's#let create_key = serde_json::from_value#let create_key: [u8; 32] = serde_json::from_value#g' $(FFI_RS)
+	@grep -q 'create_key: \[u8; 32\]' $(FFI_RS) || (echo "ERROR: create_key type patch did not apply" && exit 1)
 	@echo "✅ FFI client written to $(FFI_RS)"
 
 generate: ## Regenerate IDL and FFI client from Rust annotations (run after changing lib.rs)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 tokio = { version = "1", features = ["full"] }

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -13,17 +13,17 @@ path = "tests/e2e_member_management.rs"
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
-token_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+token_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
 risc0-zkvm = "3.0"
 borsh = "1.5"
 tokio = { version = "1", features = ["full"] }
 
 lez-multisig-ffi = { path = "../lez-multisig-ffi" }
 hex = "0.4"
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["client"] }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["client"] }
 
 
 [lib]

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 serde_json = "1"

--- a/lez-multisig-ffi/Cargo.toml
+++ b/lez-multisig-ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-spel-framework-core = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
@@ -19,10 +19,10 @@ hex = "0.4"
 bs58 = "0.5"
 
 # nssa deps for transaction building
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
 borsh = "1.5"
 sha2 = "0.10"
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }

--- a/lez-multisig-ffi/src/lib.rs
+++ b/lez-multisig-ffi/src/lib.rs
@@ -255,8 +255,8 @@ mod tests {
         // compute_vault_pda and vault_pda_seed_bytes must agree
         let vault_via_fn = compute_vault_pda(&program_id, &create_key);
         let seed_bytes = vault_pda_seed_bytes(&create_key);
-        let vault_via_seed = nssa_core::account::AccountId::from(
-            (&program_id, &nssa_core::program::PdaSeed::new(seed_bytes))
+        let vault_via_seed = nssa_core::account::AccountId::for_public_pda(
+            &program_id, &nssa_core::program::PdaSeed::new(seed_bytes)
         );
         assert_eq!(vault_via_fn, vault_via_seed, "compute_vault_pda and vault_pda_seed_bytes must agree");
     }

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 serde_json = "1"

--- a/multisig_core/Cargo.toml
+++ b/multisig_core/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh = "1.5.7"

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", branch = "main" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true


### PR DESCRIPTION
Supersedes #34 (which targeted v0.2.0-rc.5 — now leapfrogged by the stable release).

## What

Bumps all SPEL and LEZ/nssa dependencies to their current stable versions.

## Changes

- **SPEL `branch=main` → `tag=v0.3.0`** across all 5 crates that depend on it (`multisig_program`, `methods/guest`, `idl-gen`, `cli`, `lez-multisig-ffi`)
- **nssa/LEZ `v0.2.0-rc1` → `v0.2.0-rc3`** — required because SPEL v0.3.0 pins nssa at rc3; mismatched versions cause type incompatibility at the crate boundary. Affected: workspace `Cargo.toml`, `multisig_core`, `lez-multisig-ffi`, `e2e_tests`
- **`AccountId::from((&program_id, &pda_seed))` → `AccountId::for_public_pda()`** in `lez-multisig-ffi/src/lib.rs` test — nssa rc3 removed the `From<(&ProgramId, &PdaSeed)>` impl in favour of explicit `for_public_pda` / `for_private_pda` methods
- **Makefile / CI / e2e.yml / spel-compat.yml**: derive SPEL tag from `lez-multisig-ffi/Cargo.toml` at runtime (same approach as PR #34); drop now-unused `SPEL_REF` env var; update `LSSA_REF` to `v0.2.0-rc3`

## Testing

- 28 unit tests (`multisig_core` + `multisig_program`) — all pass
- 2 FFI tests (`lez-multisig-ffi`) — all pass
- `cargo check --workspace` — clean (only pre-existing `mut` warnings in generated `multisig.rs`)

## Notes on SPEL v0.3.0 changes (backward-compatible for this repo)

- `SpelOutput` is now `#[non_exhaustive]` — no impact, we only use `execute()` builder
- Removed deprecated `states_only()`, `with_chained_calls()`, old 4-tuple `into_parts()` — none were used here
- New opt-in features (validity windows, `ProgramContext`, private PDAs, `#[account_type]` C FFI fetch functions) require no changes to adopt

Closes #34