### PR TITLE
fix(#40): commit target_account_ids and bind external accounts at execute

### DIFF
--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -274,6 +274,7 @@ async fn test_multisig_token_transfer() {
             target_program_id: token_program_id,
             target_instruction_data: vault_init_instruction_data,
             target_account_count: 2,   // def_id + vault_id
+            target_account_ids: vec![*def_id.value(), *vault_id.value()], // bound at propose time (#40)
             pda_seeds: vec![vault_seed],
             authorized_indices: vec![1], // vault at index 1
             create_key,
@@ -372,6 +373,7 @@ async fn test_multisig_token_transfer() {
             target_program_id: token_program_id,
             target_instruction_data: target_instruction_data.clone(),
             target_account_count: 2,     // vault (index 0) + recipient (index 1)
+            target_account_ids: vec![*vault_id.value(), *recipient_id.value()], // bound at propose time (#40)
             pda_seeds: vec![vault_seed], // vault is PDA of multisig
             authorized_indices: vec![0], // vault (sender) at index 0 must be authorized
             create_key,

--- a/lez-multisig-ffi/include/lez_multisig.h
+++ b/lez-multisig-ffi/include/lez_multisig.h
@@ -58,6 +58,10 @@ char* lez_multisig_create(const char* args_json);
  *   "target_program_id":       "hex64",
  *   "target_instruction_data": "hex (encoded bytes)",
  *   "target_account_count":    3,
+ *   "target_account_ids":      ["hex64", ...],  (the approved transfer targets;
+ *                                                length MUST equal target_account_count.
+ *                                                Bound at propose time so the executor
+ *                                                cannot substitute the destination — issue #40)
  *   "pda_seeds":               ["hex64", ...],
  *   "authorized_indices":      [0, 1]
  * }
@@ -130,6 +134,7 @@ char* lez_multisig_execute(const char* args_json);
  *       "proposer": "hex64",
  *       "target_program_id": "hex64",
  *       "target_account_count": 3,
+ *       "target_account_ids": ["hex64", ...],  (approved destinations — issue #40)
  *       "approved_count": 2,
  *       "rejected_count": 0,
  *       "status": "Active|Approved|Rejected|Executed",

--- a/multisig_core/src/lib.rs
+++ b/multisig_core/src/lib.rs
@@ -50,6 +50,10 @@ pub enum Instruction {
         target_instruction_data: Vec<u32>,
         /// Number of target accounts that will be passed at execute time.
         target_account_count: u8,
+        /// Account IDs of the external target accounts, committed at proposal
+        /// time and verified at execute time. Without these, an executor could
+        /// substitute arbitrary accounts (e.g. redirect a transfer recipient).
+        target_account_ids: Vec<[u8; 32]>,
         /// PDA seeds for authorization in the chained call
         pda_seeds: Vec<[u8; 32]>,
         /// Which target account indices (0-based) get `is_authorized = true`
@@ -159,6 +163,10 @@ pub struct Proposal {
     pub target_instruction_data: Vec<u32>,
     /// Expected number of target accounts at execute time
     pub target_account_count: u8,
+    /// Account IDs of the external target accounts, committed at proposal time.
+    /// Execute verifies the supplied accounts against this list so an executor
+    /// cannot substitute arbitrary accounts for the ones members approved.
+    pub target_account_ids: Vec<[u8; 32]>,
     /// PDA seeds for the chained call (multisig proves ownership)
     pub pda_seeds: Vec<[u8; 32]>,
     /// Which target account indices (0-based) get `is_authorized = true`
@@ -183,6 +191,7 @@ impl Proposal {
         target_program_id: ProgramId,
         target_instruction_data: Vec<u32>,
         target_account_count: u8,
+        target_account_ids: Vec<[u8; 32]>,
         pda_seeds: Vec<[u8; 32]>,
         authorized_indices: Vec<u8>,
     ) -> Self {
@@ -193,6 +202,7 @@ impl Proposal {
             target_program_id,
             target_instruction_data,
             target_account_count,
+            target_account_ids,
             pda_seeds,
             authorized_indices,
             approved: vec![proposer],
@@ -216,6 +226,7 @@ impl Proposal {
             target_program_id: [0u32; 8],
             target_instruction_data: vec![],
             target_account_count: 0,
+            target_account_ids: vec![],
             pda_seeds: vec![],
             authorized_indices: vec![],
             approved: vec![proposer],

--- a/multisig_program/src/approve.rs
+++ b/multisig_program/src/approve.rs
@@ -87,6 +87,7 @@ mod tests {
             fake_program_id,
             vec![0u32],
             1,
+            vec![[0u8; 32]],
             vec![],
             vec![],
         );

--- a/multisig_program/src/execute.rs
+++ b/multisig_program/src/execute.rs
@@ -121,6 +121,19 @@ pub fn handle(
             target_accounts.len()
         );
 
+        // Bind every supplied account to the one committed at proposal time.
+        // Only PDA accounts are otherwise constrained (via pda_seeds); without
+        // this check the executor could substitute arbitrary external accounts
+        // — e.g. redirect an approved token transfer to a different recipient.
+        for (i, target) in target_accounts.iter().enumerate() {
+            assert_eq!(
+                *target.account_id.value(),
+                proposal.target_account_ids[i],
+                "Target account {} does not match the approved proposal",
+                i
+            );
+        }
+
         let target_program_id = proposal.target_program_id.clone();
         let target_instruction_data = proposal.target_instruction_data.clone();
         let pda_seeds: Vec<PdaSeed> = proposal.pda_seeds.iter().map(|s| PdaSeed::new(*s)).collect();
@@ -191,7 +204,11 @@ mod tests {
         borsh::to_vec(&MultisigState::new([0u8; 32], threshold, members)).unwrap()
     }
 
-    fn make_proposal_with_approvals(approvals: Vec<[u8; 32]>, target_account_count: u8) -> Vec<u8> {
+    fn make_proposal_with_approvals(
+        approvals: Vec<[u8; 32]>,
+        target_account_count: u8,
+        target_account_ids: Vec<[u8; 32]>,
+    ) -> Vec<u8> {
         let fake_program_id: ProgramId = [42u32; 8];
         let mut proposal = Proposal::new(
             1,
@@ -200,6 +217,7 @@ mod tests {
             fake_program_id,
             vec![0u32],
             target_account_count,
+            target_account_ids,
             vec![],
             vec![0u8], // first target account is authorized
         );
@@ -214,7 +232,7 @@ mod tests {
         let members = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
         let state_data = make_state(2, members);
         // 2 approvals (member 1 auto, member 2 added)
-        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1);
+        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1, vec![[30u8; 32]]);
 
         let accounts = vec![
             make_account(&[10u8; 32], state_data, false),   // multisig state
@@ -239,13 +257,35 @@ mod tests {
         assert!(chained[0].pre_states[0].is_authorized);
     }
 
+    // Security regression for #40: a fully-approved proposal that targets
+    // recipient X must NOT execute when the executor substitutes recipient Y.
+    // The proposal commits target_account_ids = [X]; execute must reject Y.
+    #[test]
+    #[should_panic(expected = "does not match the approved proposal")]
+    fn test_execute_rejects_substituted_target_account() {
+        let members = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
+        let state_data = make_state(2, members);
+        // Approved to send to recipient X = [30; 32]
+        let proposal_data =
+            make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1, vec![[30u8; 32]]);
+
+        let accounts = vec![
+            make_account(&[10u8; 32], state_data, false),    // multisig state
+            make_account(&[1u8; 32], vec![], true),            // executor (member)
+            make_account(&[20u8; 32], proposal_data, false),   // proposal PDA
+            make_account(&[99u8; 32], vec![], false),          // ATTACK: Y, not approved X
+        ];
+
+        handle(&accounts, 1);
+    }
+
     #[test]
     #[should_panic(expected = "enough approvals")]
     fn test_execute_below_threshold_fails() {
         let members = vec![[1u8; 32], [2u8; 32], [3u8; 32]];
         let state_data = make_state(2, members);
         // Only 1 approval (proposer only)
-        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32]], 1);
+        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32]], 1, vec![[30u8; 32]]);
 
         let accounts = vec![
             make_account(&[10u8; 32], state_data, false),
@@ -262,7 +302,7 @@ mod tests {
     fn test_execute_wrong_account_count_fails() {
         let members = vec![[1u8; 32], [2u8; 32]];
         let state_data = make_state(2, members);
-        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1);
+        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1, vec![[30u8; 32]]);
 
         // Missing the target account
         let accounts = vec![
@@ -280,7 +320,7 @@ mod tests {
     fn test_execute_non_member_fails() {
         let members = vec![[1u8; 32], [2u8; 32]];
         let state_data = make_state(2, members);
-        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1);
+        let proposal_data = make_proposal_with_approvals(vec![[1u8; 32], [2u8; 32]], 1, vec![[30u8; 32]]);
 
         let accounts = vec![
             make_account(&[10u8; 32], state_data, false),

--- a/multisig_program/src/lib.rs
+++ b/multisig_program/src/lib.rs
@@ -49,6 +49,7 @@ mod multisig_program {
         target_program_id: ProgramId,
         target_instruction_data: Vec<u32>,
         target_account_count: u8,
+        target_account_ids: Vec<[u8; 32]>,
         pda_seeds: Vec<[u8; 32]>,
         authorized_indices: Vec<u8>,
         create_key: [u8; 32],
@@ -60,6 +61,7 @@ mod multisig_program {
             &target_program_id,
             &target_instruction_data,
             target_account_count,
+            &target_account_ids,
             &pda_seeds,
             &authorized_indices,
         );

--- a/multisig_program/src/propose.rs
+++ b/multisig_program/src/propose.rs
@@ -14,6 +14,7 @@ pub fn handle(
     target_program_id: &ProgramId,
     target_instruction_data: &InstructionData,
     target_account_count: u8,
+    target_account_ids: &[[u8; 32]],
     pda_seeds: &[[u8; 32]],
     authorized_indices: &[u8],
 ) -> (Vec<Account>, Vec<ChainedCall>) {
@@ -39,6 +40,16 @@ pub fn handle(
     let proposer_id = *proposer_account.account_id.value();
     assert!(state.is_member(&proposer_id), "Proposer is not a multisig member");
 
+    // The committed account-id list must cover exactly the declared targets, so
+    // execute can bind every supplied account back to one the members approved.
+    assert_eq!(
+        target_account_ids.len(),
+        target_account_count as usize,
+        "target_account_ids length ({}) must equal target_account_count ({})",
+        target_account_ids.len(),
+        target_account_count
+    );
+
     let proposal_index = state.next_proposal_index();
 
     // Create the proposal
@@ -49,6 +60,7 @@ pub fn handle(
         target_program_id.clone(),
         target_instruction_data.clone(),
         target_account_count,
+        target_account_ids.to_vec(),
         pda_seeds.to_vec(),
         authorized_indices.to_vec(),
     );
@@ -108,6 +120,7 @@ mod tests {
             &program_id,
             &vec![0u32],
             1,
+            &[[30u8; 32]],
             &[],
             &[],
         );
@@ -144,7 +157,7 @@ mod tests {
         ];
 
         let program_id: ProgramId = [42u32; 8];
-        handle(&accounts, &program_id, &vec![0u32], 1, &[], &[]);
+        handle(&accounts, &program_id, &vec![0u32], 1, &[[30u8; 32]], &[], &[]);
     }
 
     #[test]
@@ -160,6 +173,6 @@ mod tests {
         ];
 
         let program_id: ProgramId = [42u32; 8];
-        handle(&accounts, &program_id, &vec![0u32], 1, &[], &[]);
+        handle(&accounts, &program_id, &vec![0u32], 1, &[[30u8; 32]], &[], &[]);
     }
 }

--- a/multisig_program/src/reject.rs
+++ b/multisig_program/src/reject.rs
@@ -92,6 +92,7 @@ mod tests {
             fake_program_id,
             vec![0u32],
             1,
+            vec![[0u8; 32]],
             vec![],
             vec![],
         );

--- a/scripts/DEMO-RUNBOOK.md
+++ b/scripts/DEMO-RUNBOOK.md
@@ -286,11 +286,18 @@ PROP_TOKEN="<base58>"
 # variant=0 (Transfer), u128(200) = 5 words: [0, 200, 0, 0, 0]
 TARGET_IX_DATA="0,200,0,0,0"
 
+# #40: bind the approved destinations INTO the proposal so the executor cannot
+# substitute them. Same order the executor passes in --target-accounts-account
+# below: [vault, recipient]. Encoding confirmed via `propose --help`:
+#   --target-account-ids  Vec<[u8;32]>  — format: HEX64,...  (comma-separated, like --pda-seeds)
+TARGET_IDS=$(python3 -c "import base58; print(','.join(base58.b58decode(a).hex() for a in ['$VAULT_PDA','$RECIPIENT']))")
+
 $MULTISIG --idl $IDL --program $MULTISIG_BIN \
   propose \
     --target-program-id       $TOKEN_PROGRAM_ID \
     --target-instruction-data $TARGET_IX_DATA \
     --target-account-count    2 \
+    --target-account-ids      $TARGET_IDS \
     --pda-seeds               $VAULT_SEED \
     --authorized-indices      0 \
     --multisig-state-account  $MULTISIG_STATE \


### PR DESCRIPTION
Fixes #40.

## Problem

At execute time the only target accounts that were constrained were PDAs
(verified via the stored `pda_seeds`). External (non-PDA) accounts were passed
straight through to the target program with **no verification** against the
approved proposal. An approved proposal for a token transfer to recipient `X`
could be executed by anyone supplying recipient `Y` instead — the multisig
provided no guarantee over the external accounts it approved.

## Fix

Commit the target account ids in the `Proposal` at propose time, and bind every
supplied target account to the committed one at execute time.

- **`multisig_core/src/lib.rs`** (annotation change): add
  `target_account_ids: Vec<[u8; 32]>` to the `Instruction::Propose` variant and
  to the `Proposal` struct, so the account ids are committed when the proposal
  is created.
- **`multisig_program/src/propose.rs`**: require
  `target_account_ids.len() == target_account_count` so the committed list
  covers exactly the declared targets.
- **`multisig_program/src/execute.rs`**: assert each supplied target account id
  equals `proposal.target_account_ids[i]`; reject otherwise. The index is safe
  via the invariant chain
  `target_accounts.len() == target_account_count == target_account_ids.len()`.
- Propagate the new field through the hand-maintained FFI C header
  (`lez-multisig-ffi/include/lez_multisig.h`), the e2e test and the demo runbook.

This follows the required-fix outline in the issue (parts 1, 2 and the FFI
edge). The generated FFI client (`multisig.rs`, produced by `make generate-ffi`)
is **not** touched — only the hand-maintained header is.

## Out of scope (follow-up)

Issue parts 3–4 — the `LezMultisigBackend` (.h/.cpp) and the QML form
(`qml/Main.qml`) that would collect external account pubkeys in the wallet UI —
live in the Basecamp wallet-module repo, not in this repository. They need a
separate change there.

## Testing

- `cargo test -p multisig_program -p multisig_core` → **29 passed, 0 failed**.
- New regression test `test_execute_rejects_substituted_target_account`
  reproduces the exact attack: a proposal approved for target `X` is rejected
  when the executor substitutes `Y` (`#[should_panic(expected = "does not match
  the approved proposal")]`).
- FFI/CLI/e2e build verified against circuits v0.4.2.
