### PR TITLE
chore: migrate to SPEL v0.6.0 and LEZ v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,20 +20,15 @@ jobs:
         with:
           prefix-key: "ci"
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install spel-client-gen
         run: |
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --tag "$SPEL_TAG" \
-            spel-client-gen \
-            --locked
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          if [ -n "$SPEL_TAG" ]; then
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+          else
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+          fi
 
       - name: Install cbindgen
         run: cargo install cbindgen --version 0.29.2 --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
           if [ -n "$SPEL_TAG" ]; then
-            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen
           else
-            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen
           fi
 
       - name: Install cbindgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, "*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
-          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+' || true)
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+' || true)
           if [ -n "$SPEL_TAG" ]; then
             cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
               || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc3"
+  LSSA_REF: "v0.2.0"
 
 jobs:
   unit-tests:
@@ -167,7 +167,7 @@ jobs:
         run: |
           cd /tmp/lssa
           rm -rf rocksdb
-          /tmp/lssa/target/release/sequencer_service sequencer/service/configs/debug/sequencer_config.json > /tmp/sequencer.log 2>&1 &
+          /tmp/lssa/target/release/sequencer_service lez/sequencer/service/configs/debug/sequencer_config.json > /tmp/sequencer.log 2>&1 &
           echo "Waiting for sequencer..."
           for i in $(seq 1 60); do
             CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3040 2>/dev/null || echo "000")
@@ -187,7 +187,7 @@ jobs:
       - name: Run e2e tests
         env:
           MULTISIG_PROGRAM: ${{ github.workspace }}/target/riscv32im-risc0-zkvm-elf/docker/multisig.bin
-          TOKEN_PROGRAM: /tmp/lssa/artifacts/program_methods/token.bin
+          TOKEN_PROGRAM: /tmp/lssa/artifacts/lez/programs/token.bin
           SEQUENCER_URL: http://127.0.0.1:3040
         run: cargo test -p lez-multisig-e2e -- --nocapture --test-threads=1
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,11 @@ jobs:
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
           if [ -n "$SPEL_TAG" ]; then
-            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen
           else
-            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen
           fi
 
       - name: Generate IDL + FFI client
@@ -95,9 +97,11 @@ jobs:
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
           SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
           if [ -n "$SPEL_TAG" ]; then
-            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen
           else
-            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked 2>/dev/null \
+              || cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen
           fi
 
       - name: Generate IDL + FFI client

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -92,6 +92,16 @@ jobs:
           prefix-key: "e2e"
           cache-targets: true
 
+      - name: Install logos-blockchain-circuits
+        run: |
+          PLATFORM="linux-x86_64"
+          VERSION="v0.4.2"
+          ARTIFACT="logos-blockchain-circuits-${VERSION}-${PLATFORM}.tar.gz"
+          URL="https://github.com/logos-blockchain/logos-blockchain-circuits/releases/download/${VERSION}/${ARTIFACT}"
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -o "/tmp/${ARTIFACT}" "$URL"
+          mkdir -p "$HOME/.logos-blockchain-circuits"
+          tar -xzf "/tmp/${ARTIFACT}" -C "$HOME/.logos-blockchain-circuits" --strip-components=1
+
       - name: Install spel-client-gen
         run: |
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+' || true)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc3"
+  LSSA_REF: "v0.2.0"
 
 jobs:
   unit-tests:
@@ -21,20 +21,15 @@ jobs:
         with:
           prefix-key: "unit"
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install spel-client-gen
         run: |
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --tag "$SPEL_TAG" \
-            spel-client-gen \
-            --locked
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          if [ -n "$SPEL_TAG" ]; then
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+          else
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+          fi
 
       - name: Generate IDL + FFI client
         env:
@@ -95,20 +90,15 @@ jobs:
           prefix-key: "e2e"
           cache-targets: true
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install spel-client-gen
         run: |
           SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          cargo install \
-            --git https://github.com/logos-co/spel.git \
-            --tag "$SPEL_TAG" \
-            spel-client-gen \
-            --locked
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          if [ -n "$SPEL_TAG" ]; then
+            cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked
+          else
+            cargo install --git https://github.com/logos-co/spel.git --rev "$SPEL_REV" spel-client-gen --locked
+          fi
 
       - name: Generate IDL + FFI client
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0"
+  LSSA_REF: "v0.2.0-rc3"
 
 jobs:
   unit-tests:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
-          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+' || true)
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+' || true)
           if [ -n "$SPEL_TAG" ]; then
             cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
               || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen
@@ -94,8 +94,8 @@ jobs:
 
       - name: Install spel-client-gen
         run: |
-          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
-          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
+          SPEL_TAG=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+' || true)
+          SPEL_REV=$(grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+' || true)
           if [ -n "$SPEL_TAG" ]; then
             cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen --locked 2>/dev/null \
               || cargo install --git https://github.com/logos-co/spel.git --tag "$SPEL_TAG" spel-client-gen

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -187,6 +187,16 @@ jobs:
           prefix-key: "spel-compat-e2e"
           cache-targets: true
 
+      - name: Install logos-blockchain-circuits
+        run: |
+          PLATFORM="linux-x86_64"
+          VERSION="v0.4.2"
+          ARTIFACT="logos-blockchain-circuits-${VERSION}-${PLATFORM}.tar.gz"
+          URL="https://github.com/logos-blockchain/logos-blockchain-circuits/releases/download/${VERSION}/${ARTIFACT}"
+          curl -L -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -o "/tmp/${ARTIFACT}" "$URL"
+          mkdir -p "$HOME/.logos-blockchain-circuits"
+          tar -xzf "/tmp/${ARTIFACT}" -C "$HOME/.logos-blockchain-circuits" --strip-components=1
+
       - name: Install spel-client-gen
         run: |
           cargo install \

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc3"
+  LSSA_REF: "v0.2.0"
 
 jobs:
   unit-tests:
@@ -257,7 +257,7 @@ jobs:
         run: |
           cd /tmp/lssa
           rm -rf rocksdb
-          /tmp/lssa/target/release/sequencer_service sequencer/service/configs/debug/sequencer_config.json > /tmp/sequencer.log 2>&1 &
+          /tmp/lssa/target/release/sequencer_service lez/sequencer/service/configs/debug/sequencer_config.json > /tmp/sequencer.log 2>&1 &
           echo "Waiting for sequencer..."
           for i in $(seq 1 60); do
             CODE=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:3040 2>/dev/null || echo "000")
@@ -277,7 +277,7 @@ jobs:
       - name: Run e2e tests
         env:
           MULTISIG_PROGRAM: ${{ github.workspace }}/target/riscv32im-risc0-zkvm-elf/docker/multisig.bin
-          TOKEN_PROGRAM: /tmp/lssa/artifacts/program_methods/token.bin
+          TOKEN_PROGRAM: /tmp/lssa/artifacts/lez/programs/token.bin
           SEQUENCER_URL: http://127.0.0.1:3040
         run: cargo test -p lez-multisig-e2e -- --nocapture --test-threads=1
 

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0-rc3"
+  LSSA_REF: "v0.2.0"
 
 jobs:
   unit-tests:
@@ -75,12 +75,6 @@ jobs:
         run: |
           find . -name "Cargo.toml" | xargs sed -i -E \
             's#(git = "https://github.com/logos-co/spel\.git"), (branch|rev|tag) = "[^"]*"#\1, rev = "${{ steps.spel.outputs.sha }}"#g'
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install spel-client-gen
         run: |
@@ -192,12 +186,6 @@ jobs:
         with:
           prefix-key: "spel-compat-e2e"
           cache-targets: true
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install spel-client-gen
         run: |

--- a/.github/workflows/spel-compat.yml
+++ b/.github/workflows/spel-compat.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RISC0_VERSION: "3.0.5"
-  LSSA_REF: "v0.2.0"
+  LSSA_REF: "v0.2.0-rc3"
 
 jobs:
   unit-tests:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,10 +73,10 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
- "nssa_core",
+ "lee_core",
  "risc0-zkvm",
  "serde",
 ]
@@ -136,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "archery"
@@ -151,43 +157,14 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-bn254"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
+ "ark-ec",
+ "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-crypto-primitives"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3a13b34da09176a8baba701233fdffbaa7c1b1192ce031a3da4e55ce1f1a56"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.2",
- "ark-snark 0.4.0",
- "ark-std 0.4.0",
- "blake2",
- "derivative",
- "digest",
- "sha2",
+ "ark-std",
 ]
 
 [[package]]
@@ -198,15 +175,15 @@ checksum = "1e0c292754729c8a190e50414fd1a37093c786c709899f29c9f7daccecfa855e"
 dependencies = [
  "ahash",
  "ark-crypto-primitives-macros",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-relations 0.5.1",
- "ark-serialize 0.5.0",
- "ark-snark 0.5.1",
- "ark-std 0.5.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-snark",
+ "ark-std",
  "blake2",
  "derivative",
- "digest",
+ "digest 0.10.7",
  "fnv",
  "merlin",
  "sha2",
@@ -220,24 +197,7 @@ checksum = "e7e89fe77d1f0f4fe5b96dfc940923d88d17b6a773808124f21e764dfb063c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -247,10 +207,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -263,36 +223,16 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
- "digest",
+ "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
  "num-bigint",
@@ -303,35 +243,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -344,22 +261,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-groth16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ceafa83848c3e390f1cbf124bc3193b3e639b3f02009e0e290809a501b95fc"
-dependencies = [
- "ark-crypto-primitives 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -368,26 +270,13 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
 dependencies = [
- "ark-crypto-primitives 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-relations 0.5.1",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
+ "ark-crypto-primitives",
+ "ark-ec",
+ "ark-ff",
+ "ark-poly",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -397,9 +286,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -411,10 +300,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
 dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-relations 0.5.1",
- "ark-std 0.5.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-relations",
+ "ark-std",
  "educe",
  "num-bigint",
  "num-integer",
@@ -424,38 +313,14 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00796b6efc05a3f48225e59cb6a2cda78881e7c390872d5786aaf112f31fb4f0"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "ark-relations"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-std",
  "tracing",
  "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
- "digest",
- "num-bigint",
 ]
 
 [[package]]
@@ -464,22 +329,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize-derive",
+ "ark-std",
  "arrayvec",
- "digest",
+ "digest 0.10.7",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -490,19 +344,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-snark"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d3cc6833a335bb8a600241889ead68ee89a3cf8448081fb7694c0fe503da63"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-relations 0.4.0",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -511,20 +353,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-relations 0.5.1",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
+ "ark-ff",
+ "ark-relations",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -534,7 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -551,9 +383,64 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "asn1_der"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
+
+[[package]]
+name = "associated_token_account_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "lee_core",
+ "risc0-zkvm",
+ "serde",
+]
 
 [[package]]
 name = "astro-float"
@@ -585,8 +472,47 @@ checksum = "86887daca11d02e0b04f37a9cb81888aae881397fb48ff66494e356aea97554a"
 dependencies = [
  "itertools 0.10.5",
  "lazy_static",
- "rand 0.8.5",
- "serde",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -608,7 +534,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -619,17 +545,20 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "ata_core"
-version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
 dependencies = [
- "nssa_core",
- "risc0-zkvm",
- "serde",
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -639,10 +568,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "attohttpc"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
+dependencies = [
+ "http 0.2.12",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http 1.4.2",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "authenticated_transfer_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -654,7 +614,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -686,7 +646,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "mime",
@@ -695,6 +655,16 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
 ]
 
 [[package]]
@@ -718,6 +688,12 @@ dependencies = [
  "const-str",
  "match-lookup",
 ]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base58"
@@ -765,9 +741,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "hex-conservative",
 ]
@@ -780,9 +756,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake2"
@@ -790,7 +766,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -810,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -832,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -843,15 +819,24 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "bridge_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "lee_core",
+ "serde",
 ]
 
 [[package]]
@@ -864,29 +849,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_utils"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "anyhow",
+ "risc0-binfmt",
+]
+
+[[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -897,27 +891,27 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 dependencies = [
  "serde_core",
 ]
@@ -947,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -974,32 +968,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "cfg_eval"
-version = "0.1.2"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "cfg-if",
+ "cipher 0.5.2",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
+name = "chkstk_stub"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "047f6ab2f3b9bcaf23b593d1580898e4244d27eadf1a1fae99212ee5735d3d1c"
 dependencies = [
- "cfg-if",
- "cipher 0.5.1",
- "cpufeatures 0.3.0",
+ "cc",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -1019,20 +1012,20 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1052,14 +1045,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1071,11 +1064,17 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
- "nssa_core",
+ "lee_core",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1105,28 +1104,40 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "anyhow",
+ "authenticated_transfer_core",
  "base64",
  "borsh",
  "clock_core",
  "hex",
+ "lee",
+ "lee_core",
  "log",
  "logos-blockchain-common-http-client",
- "nssa",
- "nssa_core",
+ "programs",
  "serde",
  "serde_with",
  "sha2",
+ "system_accounts",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "console"
-version = "0.16.3"
+name = "concurrent-queue"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1136,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1153,6 +1164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1180,15 @@ name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1205,15 +1231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,19 +1249,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
+name = "crc32fast"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1277,11 +1312,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1294,6 +1331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1302,7 +1348,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "serde",
@@ -1318,7 +1364,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1352,7 +1398,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1365,7 +1411,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1376,7 +1422,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1387,20 +1433,20 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1408,12 +1454,43 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1422,9 +1499,33 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1433,7 +1534,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1466,7 +1566,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1476,7 +1576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1494,10 +1594,11 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1508,9 +1609,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1536,13 +1647,24 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -1556,6 +1678,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "duplicate"
@@ -1580,13 +1708,13 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
+ "der 0.7.10",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "serdect",
  "signature",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1595,6 +1723,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
+ "pkcs8 0.10.2",
  "serde",
  "signature",
 ]
@@ -1623,14 +1752,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elf"
@@ -1646,12 +1775,12 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "serdect",
@@ -1687,30 +1816,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
+name = "enum-as-inner"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1718,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1746,10 +1887,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "faucet_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "lee_core",
+ "serde",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ff"
@@ -1768,10 +1950,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1812,7 +2014,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1852,6 +2054,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +2097,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,7 +2114,18 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1909,9 +2142,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
  "gloo-timers",
  "send_wrapper",
@@ -1947,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.3.5"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+checksum = "ab4e5aa225bc56696909483320f0ff9b600f1a971b52e07a17d70f3d9b43254b"
 dependencies = [
  "rustversion",
  "serde_core",
@@ -1976,24 +2209,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2016,7 +2248,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 1.4.2",
  "js-sys",
  "pin-project",
  "serde",
@@ -2029,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2065,16 +2297,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2090,9 +2322,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
 ]
@@ -2104,14 +2336,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -2127,6 +2369,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2150,6 +2398,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d00147af6310f4392a31680db52a3ed45a2e0f68eb18e8c3fe5537ecc96d9e2"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.5",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5762f69ebdbd4ddb2e975cd24690bf21fe6b2604039189c26acddbc427f12887"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,7 +2465,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2186,9 +2487,20 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2196,23 +2508,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.2",
  "http-body",
  "pin-project-lite",
 ]
@@ -2231,9 +2543,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "humantime-serde"
@@ -2247,25 +2559,26 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "ctutils",
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.2",
  "http-body",
  "httparse",
  "httpdate",
@@ -2278,11 +2591,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "log",
@@ -2332,15 +2645,15 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.5",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -2454,12 +2767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2478,12 +2785,87 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+dependencies = [
+ "async-io",
+ "core-foundation 0.9.4",
+ "fnv",
+ "futures",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.28.0",
+ "netlink-proto",
+ "netlink-sys",
+ "rtnetlink",
+ "system-configuration 0.7.0",
+ "tokio",
+ "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+dependencies = [
+ "async-trait",
+ "attohttpc 0.24.1",
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.8.7",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc 0.30.1",
+ "bytes",
+ "futures",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.5",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -2510,16 +2892,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2548,20 +2930,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2604,35 +2989,36 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jf-crhf"
-version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/jellyfish?tag=jf-crhf-v0.1.1#8f3dce0bc2bd161b4648f6ac029dcc1a23aaf4c5"
+version = "0.2.0"
+source = "git+https://github.com/EspressoSystems/jellyfish?tag=jf-crhf-v0.2.0#f1538793f7f0e391495cb17bbb0c8703ec5f689d"
 dependencies = [
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
 name = "jf-poseidon2"
-version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?rev=dc166cf0f803c3e5067f9dfcc21e3dade986a447#dc166cf0f803c3e5067f9dfcc21e3dade986a447"
+version = "0.2.0"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?rev=8d80230358e900f8d63765a937f63f4978ca1daa#8d80230358e900f8d63765a937f63f4978ca1daa"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
+ "ark-bn254",
+ "ark-ff",
+ "ark-std",
  "displaydoc",
  "hex",
  "jf-crhf",
  "lazy_static",
- "nimue",
+ "spongefish",
  "zeroize",
 ]
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "961d16382652bfdd8c6f68b223b26a8c93e0d475c672f414411db31c6c5c900e"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -2642,13 +3028,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "d0879bd39df99c4c5e2c6615ccc026391a423dde10532c573e6086eb94a802cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2692,18 +3078,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2733,7 +3118,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http",
+ "http 1.4.2",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -2758,7 +3143,7 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
@@ -2807,7 +3192,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2816,7 +3201,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2840,7 +3225,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http",
+ "http 1.4.2",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2873,9 +3258,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2885,12 +3290,26 @@ dependencies = [
  "hmac-sha512",
  "itertools 0.14.0",
  "k256",
- "nssa",
- "nssa_core",
- "rand 0.8.5",
+ "lee",
+ "lee_core",
+ "ml-kem",
+ "rand 0.8.7",
  "serde",
  "sha2",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "keycard_wallet"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "lee",
+ "log",
+ "pyo3",
+ "serde",
+ "serde_json",
+ "zeroize",
 ]
 
 [[package]]
@@ -2913,7 +3332,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2926,10 +3345,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
+name = "lee"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "build_utils",
+ "hex",
+ "k256",
+ "lee_core",
+ "log",
+ "rand 0.8.7",
+ "risc0-binfmt",
+ "risc0-zkvm",
+ "serde",
+ "serde_with",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lee_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "base58",
+ "borsh",
+ "bytemuck",
+ "bytesize",
+ "chacha20",
+ "ml-kem",
+ "risc0-zkvm",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "lez-multisig-e2e"
@@ -2938,10 +3389,10 @@ dependencies = [
  "borsh",
  "common",
  "hex",
+ "lee",
+ "lee_core",
  "lez-multisig-ffi",
  "multisig_core",
- "nssa",
- "nssa_core",
  "risc0-zkvm",
  "sequencer_service_rpc",
  "token_core",
@@ -2957,9 +3408,9 @@ dependencies = [
  "bs58",
  "common",
  "hex",
+ "lee",
+ "lee_core",
  "multisig_core",
- "nssa",
- "nssa_core",
  "reqwest",
  "risc0-zkvm",
  "sequencer_service_rpc",
@@ -2982,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2993,24 +3444,407 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libp2p-identity"
-version = "0.2.13"
+name = "libp2p"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "b72dc443ddd0254cb49a794ed6b6728400ee446a0f7ab4a07d0209ee98de20e9"
 dependencies = [
- "bs58",
- "hkdf",
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "libp2p-allow-block-list",
+ "libp2p-autonat",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-quic",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38944b7cb981cc93f2f0fb411ff82d0e983bd226fbcc8d559639a3a73236568b"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e297bfc6cabb70c6180707f8fa05661b77ecb9cb67e8e8e1c469301358fa21d0"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "thiserror 2.0.18",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe9323175a17caa8a2ed4feaf8a548eeef5e0b72d03840a0eab4bcb0210ce1c"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
  "multihash",
+ "multistream-select",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.7",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b780a1150214155b0ed1cdf09fbd2e1b0442604f9146a431d1b21d23eef7bd7"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d558548fa3b5a8e9b66392f785921e363c57c05dcadfda4db0d41ae82d313e4a"
+dependencies = [
+ "async-channel",
+ "asynchronous-codec",
+ "base64",
+ "byteorder",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "hashlink 0.9.1",
+ "hex_fmt",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.7",
+ "regex",
+ "serde",
  "sha2",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-identify"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c06862544f02d05d62780ff590cc25a75f5c2b9df38ec7a370dcae8bb873cf"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
+name = "libp2p-identity"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "hkdf",
+ "k256",
+ "multihash",
+ "prost 0.14.4",
+ "rand 0.8.7",
+ "serde",
+ "sha2",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bab0466a27ebe955bcbc27328fae5429c5b48c915fd6174931414149802ec23"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.7",
+ "serde",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "uint",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d0ba095e1175d797540e16b62e7576846b883cb5046d4159086837b36846cc"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.7",
+ "smallvec",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce58c64292e87af624fcb86465e7dd8342e46a388d71e8fec0ab37ee789630a"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-gossipsub",
+ "libp2p-identify",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-swarm",
+ "pin-project",
+ "prometheus-client",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41432a159b00424a0abaa2c80d786cddff81055ac24aa127e0cf375f7858d880"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "quinn",
+ "rand 0.8.7",
+ "ring",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548fe44a80ff275d400f1b26b090d441d83ef73efabbeb6415f4ce37e5aed865"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-bounded",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.7",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-stream"
+version = "0.3.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826716f1ee125895f1fb44911413cba023485b552ff96c7a2159bd037ac619bb"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.7",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803399b4b6f68adb85e63ab573ac568154b193e9a640f03e0f2890eabbcb37f8"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
+ "lru",
+ "multistream-select",
+ "once_cell",
+ "rand 0.8.7",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65346fb4d36035b23fec4e7be4c320436ba53537ce9b6be1d1db1f70c905cad0"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-webpki",
+ "thiserror 2.0.18",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d457b9ecceb66e7199f049926fad447f1f17f040e8d29d690c086b4cab8ed14a"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next 0.15.1",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -3021,8 +3855,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
+ "ark-bn254",
+ "ark-ff",
  "num-bigint",
  "thiserror 1.0.69",
 ]
@@ -3050,14 +3884,14 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos-blockchain-blend-crypto"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "blake2",
  "logos-blockchain-groth16",
@@ -3065,13 +3899,13 @@ dependencies = [
  "logos-blockchain-poseidon2",
  "logos-blockchain-utils",
  "rs-merkle-tree",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "logos-blockchain-blend-message"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "blake2",
  "derivative",
@@ -3080,59 +3914,60 @@ dependencies = [
  "logos-blockchain-blend-crypto",
  "logos-blockchain-blend-proofs",
  "logos-blockchain-core",
+ "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-log-targets",
  "logos-blockchain-utils",
  "serde",
- "serde-big-array",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
 
 [[package]]
 name = "logos-blockchain-blend-proofs"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "ed25519-dalek",
- "generic-array 1.3.5",
+ "generic-array 1.4.4",
  "hex",
  "logos-blockchain-blend-crypto",
  "logos-blockchain-groth16",
  "logos-blockchain-pol",
  "logos-blockchain-poq",
+ "logos-blockchain-poseidon2",
  "logos-blockchain-utils",
  "num-bigint",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
 [[package]]
 name = "logos-blockchain-chain-broadcast-service"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "derivative",
- "futures",
  "logos-blockchain-core",
  "overwatch",
  "serde",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-chain-service"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "bytes",
+ "derivative",
  "futures",
  "logos-blockchain-chain-broadcast-service",
  "logos-blockchain-core",
@@ -3146,60 +3981,122 @@ dependencies = [
  "logos-blockchain-time-service",
  "logos-blockchain-tracing",
  "logos-blockchain-utils",
- "num-bigint",
  "overwatch",
  "serde",
  "serde_with",
- "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "time",
  "tokio",
  "tracing",
  "tracing-futures",
 ]
 
 [[package]]
-name = "logos-blockchain-circuits-prover"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+name = "logos-blockchain-circuits-build"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
 dependencies = [
- "logos-blockchain-circuits-utils",
- "tempfile",
+ "dirs",
+ "fd-lock",
+ "flate2",
+ "tar",
+ "ureq",
 ]
 
 [[package]]
-name = "logos-blockchain-circuits-utils"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+name = "logos-blockchain-circuits-common"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
 dependencies = [
- "dirs",
+ "logos-blockchain-circuits-types",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-poc-sys"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
+dependencies = [
+ "logos-blockchain-circuits-build",
+ "logos-blockchain-circuits-common",
+ "logos-blockchain-circuits-types",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-pol-sys"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
+dependencies = [
+ "logos-blockchain-circuits-build",
+ "logos-blockchain-circuits-common",
+ "logos-blockchain-circuits-types",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-poq-sys"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
+dependencies = [
+ "logos-blockchain-circuits-build",
+ "logos-blockchain-circuits-common",
+ "logos-blockchain-circuits-types",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-prover"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "rust-rapidsnark",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-signature-sys"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
+dependencies = [
+ "logos-blockchain-circuits-build",
+ "logos-blockchain-circuits-common",
+ "logos-blockchain-circuits-types",
+]
+
+[[package]]
+name = "logos-blockchain-circuits-types"
+version = "0.5.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-circuits.git?tag=v0.5.3#127626881faa975aa8e9868422cf6bbb08fcb512"
+dependencies = [
+ "bytes",
+ "libc",
 ]
 
 [[package]]
 name = "logos-blockchain-common-http-client"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "futures",
  "hex",
+ "log",
  "logos-blockchain-chain-broadcast-service",
  "logos-blockchain-chain-service",
  "logos-blockchain-core",
  "logos-blockchain-groth16",
  "logos-blockchain-http-api-common",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-log-targets",
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "logos-blockchain-core"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "bincode",
  "blake2",
  "bytes",
@@ -3210,31 +4107,34 @@ dependencies = [
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-log-targets",
+ "logos-blockchain-mmr",
  "logos-blockchain-poc",
  "logos-blockchain-pol",
  "logos-blockchain-poseidon2",
  "logos-blockchain-utils",
  "logos-blockchain-utxotree",
  "multiaddr",
- "nom",
+ "nom 8.0.0",
  "num-bigint",
+ "rpds",
  "serde",
  "strum",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
+ "time",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-cryptarchia-engine"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
- "cfg_eval",
  "logos-blockchain-pol",
  "logos-blockchain-utils",
  "serde",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tracing",
@@ -3242,32 +4142,34 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-cryptarchia-sync"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "bytes",
  "futures",
+ "libp2p",
+ "libp2p-stream",
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-engine",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_with",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-groth16"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-groth16 0.4.0",
- "ark-serialize 0.4.2",
- "generic-array 1.3.5",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-groth16",
+ "ark-serialize",
+ "generic-array 1.4.4",
  "hex",
  "num-bigint",
  "serde",
@@ -3277,31 +4179,38 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-http-api-common"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "axum",
  "logos-blockchain-core",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "serde_with",
+ "time",
  "tracing",
+ "url",
+ "utoipa",
+ "validator",
 ]
 
 [[package]]
 name = "logos-blockchain-key-management-system-keys"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "bytes",
  "ed25519-dalek",
- "generic-array 1.3.5",
+ "generic-array 1.4.4",
  "hex",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-macros",
+ "logos-blockchain-log-targets",
  "logos-blockchain-poseidon2",
  "logos-blockchain-utils",
  "logos-blockchain-zksign",
@@ -3318,18 +4227,18 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-key-management-system-macros"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "logos-blockchain-ledger"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "derivative",
  "logos-blockchain-blend-crypto",
@@ -3339,29 +4248,94 @@ dependencies = [
  "logos-blockchain-cryptarchia-engine",
  "logos-blockchain-groth16",
  "logos-blockchain-key-management-system-keys",
+ "logos-blockchain-mmr",
  "logos-blockchain-pol",
  "logos-blockchain-utils",
  "logos-blockchain-utxotree",
  "num-bigint",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rpds",
  "serde",
  "serde_arrays",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
+name = "logos-blockchain-libp2p"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "async-trait",
+ "backon",
+ "blake2",
+ "either",
+ "futures",
+ "hex",
+ "igd-next 0.16.2",
+ "libp2p",
+ "logos-blockchain-cryptarchia-sync",
+ "logos-blockchain-log-targets",
+ "logos-blockchain-utils",
+ "multiaddr",
+ "natpmp",
+ "netdev",
+ "num_enum",
+ "rand 0.8.7",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "zerocopy",
+]
+
+[[package]]
+name = "logos-blockchain-log-targets"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "logos-blockchain-log-targets-macros",
+]
+
+[[package]]
+name = "logos-blockchain-log-targets-macros"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "logos-blockchain-mmr"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "ark-ff",
+ "logos-blockchain-groth16",
+ "logos-blockchain-poseidon2",
+ "rpds",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "logos-blockchain-network-service"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "futures",
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-sync",
+ "logos-blockchain-libp2p",
+ "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
  "overwatch",
+ "rand 0.8.7",
+ "rand_chacha 0.3.1",
  "serde",
  "tokio",
  "tokio-stream",
@@ -3370,49 +4344,53 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poc"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
+ "logos-blockchain-circuits-poc-sys",
  "logos-blockchain-circuits-prover",
- "logos-blockchain-circuits-utils",
+ "logos-blockchain-circuits-types",
  "logos-blockchain-groth16",
- "logos-blockchain-witness-generator",
+ "logos-blockchain-log-targets",
+ "logos-blockchain-proofs-error",
  "num-bigint",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-pol"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "astro-float",
+ "logos-blockchain-circuits-pol-sys",
  "logos-blockchain-circuits-prover",
- "logos-blockchain-circuits-utils",
+ "logos-blockchain-circuits-types",
  "logos-blockchain-groth16",
+ "logos-blockchain-log-targets",
+ "logos-blockchain-proofs-error",
  "logos-blockchain-utils",
- "logos-blockchain-witness-generator",
  "num-bigint",
  "num-traits",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-poq"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
+ "logos-blockchain-circuits-poq-sys",
  "logos-blockchain-circuits-prover",
- "logos-blockchain-circuits-utils",
+ "logos-blockchain-circuits-types",
  "logos-blockchain-groth16",
+ "logos-blockchain-log-targets",
  "logos-blockchain-pol",
- "logos-blockchain-witness-generator",
+ "logos-blockchain-proofs-error",
  "num-bigint",
  "serde",
  "serde_json",
@@ -3422,59 +4400,76 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-poseidon2"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
- "ark-bn254 0.4.0",
- "ark-ff 0.4.2",
+ "ark-bn254",
+ "ark-ff",
  "jf-poseidon2",
  "num-bigint",
 ]
 
 [[package]]
+name = "logos-blockchain-proofs-error"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
+dependencies = [
+ "logos-blockchain-circuits-types",
+ "logos-blockchain-groth16",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "logos-blockchain-services-utils"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "futures",
  "log",
+ "logos-blockchain-log-targets",
  "overwatch",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-storage-service"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "bytes",
  "futures",
  "logos-blockchain-core",
  "logos-blockchain-cryptarchia-engine",
+ "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
  "overwatch",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-time-service"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "futures",
  "log",
  "logos-blockchain-cryptarchia-engine",
+ "logos-blockchain-log-targets",
  "logos-blockchain-tracing",
+ "logos-blockchain-utils",
  "overwatch",
+ "serde",
+ "serde_with",
  "sntpc",
  "thiserror 2.0.18",
  "time",
@@ -3485,18 +4480,21 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-tracing"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
+ "flate2",
+ "logos-blockchain-log-targets",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-appender",
  "tracing-gelf",
@@ -3508,53 +4506,52 @@ dependencies = [
 
 [[package]]
 name = "logos-blockchain-utils"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "async-trait",
  "blake2",
  "cipher 0.4.4",
  "const-hex",
  "humantime",
+ "logos-blockchain-log-targets",
  "overwatch",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
+ "serde_ignored",
  "serde_with",
+ "serde_yaml",
+ "thiserror 2.0.18",
  "time",
+ "tracing",
 ]
 
 [[package]]
 name = "logos-blockchain-utxotree"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
- "ark-ff 0.4.2",
+ "ark-ff",
  "logos-blockchain-groth16",
  "logos-blockchain-poseidon2",
  "num-bigint",
  "rpds",
  "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "logos-blockchain-witness-generator"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
-dependencies = [
- "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "logos-blockchain-zksign"
-version = "0.2.1"
-source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=1da154c74b911318fb853d37261f8a05ffe513b4#1da154c74b911318fb853d37261f8a05ffe513b4"
+version = "0.1.2"
+source = "git+https://github.com/logos-blockchain/logos-blockchain.git?rev=d8711bbc3d43d3ef9755ef9b73af32fd0f703160#d8711bbc3d43d3ef9755ef9b73af32fd0f703160"
 dependencies = [
  "logos-blockchain-circuits-prover",
- "logos-blockchain-circuits-utils",
+ "logos-blockchain-circuits-signature-sys",
+ "logos-blockchain-circuits-types",
  "logos-blockchain-groth16",
+ "logos-blockchain-log-targets",
  "logos-blockchain-poseidon2",
- "logos-blockchain-witness-generator",
+ "logos-blockchain-proofs-error",
  "num-bigint",
  "serde",
  "serde_json",
@@ -3570,6 +4567,15 @@ checksum = "bdc38a304f59a03e6efa3876766a48c70a766a93f88341c3fff4212834b8e327"
 dependencies = [
  "prost 0.13.5",
  "prost-types",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3595,7 +4601,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3621,20 +4627,20 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "merlin"
@@ -3643,7 +4649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
- "keccak",
+ "keccak 0.1.6",
  "rand_core 0.6.4",
  "zeroize",
 ]
@@ -3654,7 +4660,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -3680,14 +4686,72 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.0"
+name = "minimal-lexical"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3 0.11.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3705,29 +4769,31 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
+ "url",
 ]
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "core2",
- "unsigned-varint",
+ "serde",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -3743,9 +4809,9 @@ name = "multisig-guest"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "lee_core",
  "multisig_core",
  "multisig_program",
- "nssa_core",
  "risc0-zkvm",
  "serde_json",
  "spel-framework",
@@ -3763,7 +4829,7 @@ name = "multisig_core"
 version = "0.1.0"
 dependencies = [
  "borsh",
- "nssa_core",
+ "lee_core",
  "serde",
  "spel-framework",
 ]
@@ -3773,11 +4839,25 @@ name = "multisig_program"
 version = "0.1.0"
 dependencies = [
  "borsh",
+ "lee_core",
  "multisig_core",
- "nssa_core",
  "risc0-zkvm",
  "serde",
  "spel-framework",
+]
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -3798,21 +4878,129 @@ dependencies = [
 ]
 
 [[package]]
-name = "nimue"
-version = "0.1.1"
+name = "natpmp"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dc7d3b2b7bd112c0cecf7d6f4f16a174ee7a98e27615b1d08256d0176588f2"
+checksum = "77366fa8ce34e2e1322dd97da65f11a62f451bd3daae8be6993c00800f61dd07"
 dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "digest",
- "generic-array 0.14.7",
- "hex",
- "keccak",
+ "async-trait",
+ "cc",
+ "netdev",
+ "tokio",
+]
+
+[[package]]
+name = "netdev"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f901362e84cd407be6f8cd9d3a46bccf09136b095792785401ea7d283c79b91d"
+dependencies = [
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-route 0.17.1",
+ "netlink-sys",
+ "once_cell",
+ "system-configuration 0.6.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "byteorder",
+ "libc",
+ "netlink-packet-core 0.7.0",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
  "log",
- "rand 0.8.5",
- "zeroize",
+ "netlink-packet-core 0.8.1",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core 0.8.1",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3823,50 +5011,21 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nssa"
-version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
-dependencies = [
- "anyhow",
- "borsh",
- "clock_core",
- "hex",
- "k256",
- "log",
- "nssa_core",
- "rand 0.8.5",
- "risc0-binfmt",
- "risc0-build",
- "risc0-zkvm",
- "serde",
- "serde_with",
- "sha2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "nssa_core"
-version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
-dependencies = [
- "base58",
- "borsh",
- "bytemuck",
- "bytesize",
- "chacha20",
- "k256",
- "risc0-zkvm",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3880,9 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3899,16 +5058,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3921,11 +5080,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3958,7 +5116,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3968,6 +5126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3990,15 +5157,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4011,7 +5177,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4022,9 +5188,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4065,7 +5231,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.4.2",
  "opentelemetry",
  "reqwest",
 ]
@@ -4076,12 +5242,12 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
@@ -4096,7 +5262,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
@@ -4118,7 +5284,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.3",
+ "rand 0.9.5",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -4132,7 +5298,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4161,12 +5327,18 @@ name = "overwatch-derive"
 version = "0.1.0"
 source = "git+https://github.com/logos-co/Overwatch?rev=448c192#448c192895b8311c742b1726a1bb12ee314ad95c"
 dependencies = [
- "convert_case",
+ "convert_case 0.8.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4198,6 +5370,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4214,22 +5396,22 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4244,9 +5426,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -4255,8 +5437,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4264,6 +5456,20 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "polyval"
@@ -4285,9 +5491,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -4329,22 +5535,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -4352,6 +5572,16 @@ name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4366,7 +5596,19 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4386,8 +5628,40 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
+]
+
+[[package]]
+name = "programs"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "build_utils",
+ "lee",
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4396,9 +5670,9 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "unarray",
@@ -4416,12 +5690,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4434,20 +5708,20 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4460,19 +5734,99 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
+name = "pyo3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4481,14 +5835,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4502,23 +5857,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4537,9 +5892,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4548,12 +5903,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4595,6 +5961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4604,12 +5985,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4640,14 +6034,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4657,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4668,9 +6062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4685,7 +6079,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4720,6 +6114,12 @@ dependencies = [
  "web-sys",
  "webpki-roots",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -4758,7 +6158,7 @@ dependencies = [
  "elf",
  "lazy_static",
  "postcard",
- "rand 0.9.3",
+ "rand 0.9.5",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "ruint",
@@ -4857,11 +6257,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
 dependencies = [
  "anyhow",
- "ark-bn254 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-groth16 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-groth16",
+ "ark-serialize",
  "bytemuck",
  "hex",
  "num-bigint",
@@ -4893,7 +6293,7 @@ dependencies = [
  "borsh",
  "bytemuck",
  "cfg-if",
- "digest",
+ "digest 0.10.7",
  "hex",
  "hex-literal",
  "metal",
@@ -4960,13 +6360,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "rpds"
-version = "1.2.0"
+name = "rpassword"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e75f485e819d4d3015e6c0d55d02a4fd3db47c1993d9e603e0361fba2bffb34"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rpds"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e025feb26210bc196b908e72deb063b1b4000754304341cbc168a1e72c857ebc"
 dependencies = [
  "archery",
  "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -4985,13 +6397,13 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a3ef170810c387d31b64c0b59734abb0839dac2a8d137909e271bfdec9b1e0"
 dependencies = [
- "ark-bn254 0.5.0",
- "ark-ff 0.5.0",
+ "ark-bn254",
+ "ark-ff",
  "byteorder",
  "futures",
  "light-poseidon",
  "quote",
- "rand 0.9.3",
+ "rand 0.9.5",
  "syn 1.0.109",
  "thiserror 2.0.18",
  "tiny-keccak",
@@ -5004,30 +6416,58 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ruint"
-version = "1.17.2"
+name = "rtnetlink"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.28.0",
+ "netlink-proto",
+ "netlink-sys",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ruint"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
 dependencies = [
  "borsh",
  "proptest",
- "rand 0.8.5",
- "rand 0.9.3",
+ "rand 0.8.7",
+ "rand 0.9.5",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -5041,10 +6481,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rust-rapidsnark"
+version = "0.1.3"
+source = "git+https://github.com/logos-blockchain/logos-blockchain-rust-rapidsnark.git?rev=e91187f8ccb5bbfc7bb00dac88169112428da78f#e91187f8ccb5bbfc7bb00dac88169112428da78f"
+dependencies = [
+ "anyhow",
+ "cc",
+ "chkstk_stub",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -5056,12 +6508,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5070,9 +6531,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "log",
  "once_cell",
@@ -5085,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5097,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -5134,9 +6595,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5145,9 +6606,20 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
+]
 
 [[package]]
 name = "ryu"
@@ -5229,9 +6701,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -5243,7 +6715,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5272,24 +6744,26 @@ dependencies = [
 
 [[package]]
 name = "send_wrapper"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sequencer_service_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "common",
- "nssa",
- "nssa_core",
+ "hex",
+ "lee",
+ "lee_core",
+ "serde_with",
 ]
 
 [[package]]
 name = "sequencer_service_rpc"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "jsonrpsee",
  "sequencer_service_protocol",
@@ -5303,15 +6777,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5340,14 +6805,24 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -5390,11 +6865,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5409,14 +6885,27 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5431,13 +6920,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5448,7 +6937,27 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
 ]
 
 [[package]]
@@ -5462,9 +6971,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5482,9 +6991,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -5494,9 +7009,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
@@ -5516,9 +7031,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5535,21 +7060,21 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.7",
  "sha1",
 ]
 
 [[package]]
 name = "spel"
-version = "0.4.0"
-source = "git+https://github.com/logos-co/spel.git?tag=v0.4.0#43523275e1f95b97a0cf84cd83361449ea9bd1bf"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?rev=4a1b89a0f64fc8ec66492b45514f54d705a1be90#4a1b89a0f64fc8ec66492b45514f54d705a1be90"
 dependencies = [
  "base58",
  "borsh",
  "common",
  "hex",
- "nssa",
- "nssa_core",
+ "lee",
+ "lee_core",
  "risc0-zkvm",
  "sequencer_service_rpc",
  "serde",
@@ -5562,11 +7087,11 @@ dependencies = [
 
 [[package]]
 name = "spel-framework"
-version = "0.4.0"
-source = "git+https://github.com/logos-co/spel.git?tag=v0.4.0#43523275e1f95b97a0cf84cd83361449ea9bd1bf"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?rev=4a1b89a0f64fc8ec66492b45514f54d705a1be90#4a1b89a0f64fc8ec66492b45514f54d705a1be90"
 dependencies = [
  "borsh",
- "nssa_core",
+ "lee_core",
  "serde_json",
  "spel-framework-core",
  "spel-framework-macros",
@@ -5574,39 +7099,39 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.4.0"
-source = "git+https://github.com/logos-co/spel.git?tag=v0.4.0#43523275e1f95b97a0cf84cd83361449ea9bd1bf"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?rev=4a1b89a0f64fc8ec66492b45514f54d705a1be90#4a1b89a0f64fc8ec66492b45514f54d705a1be90"
 dependencies = [
  "base58",
  "borsh",
- "nssa_core",
+ "lee_core",
  "proc-macro2",
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 1.0.69",
  "toml",
 ]
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.4.0"
-source = "git+https://github.com/logos-co/spel.git?tag=v0.4.0#43523275e1f95b97a0cf84cd83361449ea9bd1bf"
+version = "0.6.0"
+source = "git+https://github.com/logos-co/spel.git?rev=4a1b89a0f64fc8ec66492b45514f54d705a1be90#4a1b89a0f64fc8ec66492b45514f54d705a1be90"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
  "sha2",
  "spel-framework-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -5615,7 +7140,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "spongefish"
+version = "0.2.0"
+source = "git+https://github.com/arkworks-rs/spongefish.git?rev=3ded547f7f56d7f8a1fc4c9a5c0ce965310bba5f#3ded547f7f56d7f8a1fc4c9a5c0ce965310bba5f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "digest 0.10.7",
+ "hex",
+ "keccak 0.1.6",
+ "rand 0.8.7",
+ "sha3 0.10.9",
+ "thiserror 2.0.18",
+ "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -5625,7 +7178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5664,7 +7217,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5672,6 +7225,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -5686,9 +7245,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5712,7 +7271,18 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5721,7 +7291,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5737,13 +7307,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "system_accounts"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "bridge_core",
+ "clock_core",
+ "faucet_core",
+ "lee_core",
+ "programs",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5752,13 +7357,14 @@ dependencies = [
 [[package]]
 name = "testnet_initial_state"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
- "common",
  "key_protocol",
- "nssa",
- "nssa_core",
+ "lee",
+ "lee_core",
+ "programs",
  "serde",
+ "system_accounts",
 ]
 
 [[package]]
@@ -5787,7 +7393,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5798,26 +7404,25 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5827,15 +7432,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5862,9 +7467,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5878,18 +7483,18 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "borsh",
- "nssa_core",
+ "lee_core",
  "serde",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5897,7 +7502,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5910,7 +7515,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6005,14 +7610,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6021,7 +7626,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6032,14 +7637,14 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http",
+ "http 1.4.2",
  "http-body",
  "http-body-util",
  "hyper",
@@ -6058,12 +7663,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -6088,20 +7693,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6130,11 +7735,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber 0.3.23",
@@ -6148,7 +7754,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6203,9 +7809,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-loki"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3beec919fbdf99d719de8eda6adae3281f8a5b71ae40431f44dc7423053d34"
+checksum = "a8d1ad78bf74c1790b0825ddc35ad1bb9498736c51c8437796b81cadf4916cd8"
 dependencies = [
  "loki-api",
  "reqwest",
@@ -6213,7 +7819,6 @@ dependencies = [
  "serde_json",
  "snap",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -6276,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
 
 [[package]]
 name = "try-lock"
@@ -6288,9 +7893,21 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unarray"
@@ -6321,9 +7938,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -6354,6 +7971,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6364,6 +7993,35 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http 1.4.2",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -6379,6 +8037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6391,10 +8055,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vault_core"
+version = "0.1.0"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+dependencies = [
+ "lee_core",
+ "risc0-zkvm",
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -6421,16 +8159,19 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
 dependencies = [
  "amm_core",
  "anyhow",
+ "associated_token_account_core",
  "async-stream",
- "ata_core",
+ "authenticated_transfer_core",
  "base58",
  "bip39",
+ "bridge_core",
  "clap",
  "common",
+ "derive_more",
  "env_logger",
  "futures",
  "hex",
@@ -6439,20 +8180,27 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "key_protocol",
+ "keycard_wallet",
+ "lee",
+ "lee_core",
  "log",
- "nssa",
- "nssa_core",
  "optfield",
- "rand 0.8.5",
+ "programs",
+ "pyo3",
+ "rand 0.8.7",
+ "rpassword",
  "sequencer_service_rpc",
  "serde",
  "serde_json",
  "sha2",
+ "system_accounts",
  "testnet_initial_state",
  "thiserror 2.0.18",
  "token_core",
  "tokio",
  "url",
+ "vault_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -6472,27 +8220,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6503,9 +8242,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6513,9 +8252,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6523,46 +8262,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -6579,22 +8296,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6616,26 +8321,32 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.8",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -6669,6 +8380,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6682,6 +8414,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6689,7 +8432,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6700,7 +8443,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6708,6 +8451,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -6767,15 +8520,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6807,7 +8551,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -6815,20 +8559,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6844,12 +8580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6860,12 +8590,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6880,22 +8604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6910,12 +8622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6926,12 +8632,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6946,12 +8646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6964,12 +8658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6980,100 +8668,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -7094,6 +8700,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7101,14 +8749,23 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7123,35 +8780,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -7164,28 +8821,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7218,11 +8875,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,7 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -6460,9 +6460,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
 dependencies = [
  "borsh",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ members = [
 [workspace.dependencies]
 risc0-zkvm = { version = "=3.0.5", features = ['std'] }
 risc0-build = "=3.0.5"
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 borsh = "1.5.7"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,48 @@ generate-module: ## Regenerate backend/plugin/build files; preserves hand-writte
 	@echo "✅ Backend/plugin/build files written (qml/Main.qml, CMakeLists.txt, manifest.json, module.yaml preserved)"
 	$(MAKE) patch-generated
 
-patch-generated: ## Patch generated LezMultisigPlugin.cpp to register codec + spelbook context properties
+patch-generated: ## Patch generated files to register codec + spelbook context properties
+	@echo "🔧 Patching generated main.cpp (codec, spelbook, LOGOS_QML_IMPORT_PATH)..."
+	@sed -i 's|#include "LezMultisigPlugin.h"|#include "LezMultisigCodec.h"\n#include "LezMultisigPlugin.h"\n#include "LezSpelbookBridge.h"|' $(MODULE_SRC)/main.cpp 2>/dev/null || true
+	@sed -i 's|LezMultisigBackend backend(nullptr);|LezMultisigBackend backend(nullptr);\n\tLezMultisigCodec codec(nullptr);\n\tLezSpelbookBridge spelbook(nullptr);|' $(MODULE_SRC)/main.cpp 2>/dev/null || true
+	@sed -i 's|setContextProperty("backend", \&backend);|setContextProperty("backend", \&backend);\n\tview.engine()->rootContext()->setContextProperty("codec", \&codec);\n\tview.engine()->rootContext()->setContextProperty("spelbook", \&spelbook);|' $(MODULE_SRC)/main.cpp 2>/dev/null || true
+	@if ! grep -q 'LOGOS_QML_IMPORT_PATH' $(MODULE_SRC)/main.cpp; then \
+		sed -i 's|const char\* qmlPath|// Logos.Theme / Logos.Controls import path\n#ifdef LOGOS_QML_IMPORT_PATH\n\tview.engine()->addImportPath(QStringLiteral(LOGOS_QML_IMPORT_PATH));\n#endif\n\tconst char* runtimeImportPath = std::getenv("LOGOS_QML_IMPORT_PATH");\n\tif (runtimeImportPath)\n\t\tview.engine()->addImportPath(QString::fromUtf8(runtimeImportPath));\n\n\tconst char* qmlPath|' $(MODULE_SRC)/main.cpp; \
+	fi
+	@echo "  ✅ Patched: main.cpp"
+	@echo "🔧 Patching generated LezMultisigBackend.cpp (normalizeCreateKey)..."
+	@if ! grep -q 'normalizeCreateKey' $(MODULE_SRC)/LezMultisigBackend.cpp; then \
+		sed -i 's|#include <QJsonArray>|#include <QCryptographicHash>\n#include <QJsonArray>|' $(MODULE_SRC)/LezMultisigBackend.cpp; \
+		sed -i 's|#include <QSettings>|#include <QRegularExpression>\n#include <QSettings>|' $(MODULE_SRC)/LezMultisigBackend.cpp; \
+		printf '\nstatic QString normalizeCreateKey(const QString& key) {\n    static const QRegularExpression hexRe(QStringLiteral("^[0-9a-fA-F]{64}$$"));\n    if (hexRe.match(key).hasMatch()) return key;\n    return QString::fromLatin1(QCryptographicHash::hash(key.toUtf8(), QCryptographicHash::Sha256).toHex());\n}\n' >> $(MODULE_SRC)/LezMultisigBackend.cpp.tmp && \
+		head -n $$(grep -n '#include' $(MODULE_SRC)/LezMultisigBackend.cpp | tail -1 | cut -d: -f1) $(MODULE_SRC)/LezMultisigBackend.cpp > $(MODULE_SRC)/LezMultisigBackend.cpp.new && \
+		cat $(MODULE_SRC)/LezMultisigBackend.cpp.tmp >> $(MODULE_SRC)/LezMultisigBackend.cpp.new && \
+		tail -n +$$(( $$(grep -n '#include' $(MODULE_SRC)/LezMultisigBackend.cpp | tail -1 | cut -d: -f1) + 1 )) $(MODULE_SRC)/LezMultisigBackend.cpp >> $(MODULE_SRC)/LezMultisigBackend.cpp.new && \
+		mv $(MODULE_SRC)/LezMultisigBackend.cpp.new $(MODULE_SRC)/LezMultisigBackend.cpp && \
+		rm -f $(MODULE_SRC)/LezMultisigBackend.cpp.tmp && \
+		sed -i 's|args\["create_key"\] = createKey;|args["create_key"] = normalizeCreateKey(createKey);|g' $(MODULE_SRC)/LezMultisigBackend.cpp; \
+		echo "  ✅ Added: normalizeCreateKey"; \
+	else \
+		echo "  ℹ️  Skipped: normalizeCreateKey already present"; \
+	fi
+	@echo "🔧 Patching generated LezMultisigBackend.cpp (target_accounts for execute)..."
+	@if ! grep -q 'target_accounts' $(MODULE_SRC)/LezMultisigBackend.cpp; then \
+		sed -i 's|args\["create_key"\] = normalizeCreateKey(createKey);\n    dispatchFfi("execute"|args["create_key"] = normalizeCreateKey(createKey);\n    args["target_accounts"] = QJsonArray();\n    dispatchFfi("execute"|' $(MODULE_SRC)/LezMultisigBackend.cpp; \
+		python3 -c "\
+import re, sys;\
+path='$(MODULE_SRC)/LezMultisigBackend.cpp';\
+txt=open(path).read();\
+patched=re.sub(\
+    r'(void LezMultisigBackend::execute\b.*?args\[\"create_key\"\] = normalizeCreateKey\(createKey\);)',\
+    r'\1\n    args[\"target_accounts\"] = QJsonArray();',\
+    txt, flags=re.DOTALL);\
+open(path,'w').write(patched);\
+print('  patched') if patched != txt else print('  no-op')\
+"; \
+		echo "  ✅ Added: target_accounts to execute"; \
+	else \
+		echo "  ℹ️  Skipped: target_accounts already present"; \
+	fi
 	@echo "🔧 Patching generated LezMultisigPlugin.cpp..."
 	@# 1) Add codec include + context property (idempotent)
 	@if ! grep -q 'LezMultisigCodec' $(MODULE_SRC)/LezMultisigPlugin.cpp; then \
@@ -112,6 +153,52 @@ patch-generated: ## Patch generated LezMultisigPlugin.cpp to register codec + sp
 		echo "  ✅ Added: spelbook context property"; \
 	else \
 		echo "  ℹ️  Skipped: LezSpelbookBridge already present"; \
+	fi
+	@# 3) Add storage bridge include + context property (idempotent)
+	@if ! grep -q 'LezStorageBridge' $(MODULE_SRC)/LezMultisigPlugin.cpp; then \
+		sed -i 's|#include "LezSpelbookBridge.h"|#include "LezSpelbookBridge.h"\n#include "LezStorageBridge.h"|' $(MODULE_SRC)/LezMultisigPlugin.cpp; \
+		sed -i 's|setContextProperty("spelbook", new LezSpelbookBridge(this));|setContextProperty("spelbook", new LezSpelbookBridge(this));\n\tview->engine()->rootContext()->setContextProperty("storage", new LezStorageBridge(m_api, this));|' $(MODULE_SRC)/LezMultisigPlugin.cpp; \
+		echo "  ✅ Added: storage context property"; \
+	else \
+		echo "  ℹ️  Skipped: LezStorageBridge already present"; \
+	fi
+	@echo "🔧 Patching generated LezMultisigBackend.h (clearHistory, computePda)..."
+	@if ! grep -q 'clearHistory' $(MODULE_SRC)/LezMultisigBackend.h; then \
+		sed -i 's|Q_INVOKABLE void        saveHistory(const QString\& key, const QString\& value);|Q_INVOKABLE void        saveHistory(const QString\& key, const QString\& value);\n    Q_INVOKABLE void        clearHistory(const QString\& key);\n    Q_INVOKABLE QVariantMap computePda(const QString\& createKey, const QString\& purpose) const;\n    Q_INVOKABLE QString     pdaFromSeed(const QString\& seedHex) const;|' $(MODULE_SRC)/LezMultisigBackend.h; \
+		echo "  ✅ Added: clearHistory + computePda + pdaFromSeed declarations"; \
+	else \
+		echo "  ℹ️  Skipped: clearHistory already present"; \
+	fi
+	@echo "🔧 Patching generated LezMultisigBackend.cpp (clearHistory, computePda, pdaFromSeed, FFI)..."
+	@if ! grep -q 'lez_multisig_compute_pda' $(MODULE_SRC)/LezMultisigBackend.cpp; then \
+		sed -i 's|    char\* multisig_program_decode_account(const char\* args_json);|    char* multisig_program_decode_account(const char* args_json);\n    char* lez_multisig_compute_pda(const char* args_json);\n    void  lez_multisig_free_string(char* s);\n    char* lez_multisig_pda_from_seed(const char* args_json);|' $(MODULE_SRC)/LezMultisigBackend.cpp; \
+		python3 -c "\
+path='$(MODULE_SRC)/LezMultisigBackend.cpp';\
+txt=open(path).read();\
+impl='''\n\nvoid LezMultisigBackend::clearHistory(const QString& key) {\n    QSettings(\"logos-co\", \"lez_multisig\").remove(\"history/\" + key);\n}\n\nQVariantMap LezMultisigBackend::computePda(const QString& createKey, const QString& purpose) const {\n    QJsonObject args;\n    args[\"program_id_hex\"] = m_programIdHex;\n    args[\"create_key\"]     = createKey;\n    args[\"purpose\"]        = purpose;\n    QByteArray json = QJsonDocument(args).toJson(QJsonDocument::Compact);\n    char* raw = lez_multisig_compute_pda(json.constData());\n    if (!raw) return {};\n    auto result = QJsonDocument::fromJson(QByteArray(raw)).object().toVariantMap();\n    lez_multisig_free_string(raw);\n    return result;\n}\n\nQString LezMultisigBackend::pdaFromSeed(const QString& seedHex) const {\n    QJsonObject args;\n    args[\"program_id_hex\"] = m_programIdHex;\n    args[\"seed_hex\"]       = seedHex;\n    QByteArray json = QJsonDocument(args).toJson(QJsonDocument::Compact);\n    char* raw = lez_multisig_pda_from_seed(json.constData());\n    if (!raw) return {};\n    auto obj = QJsonDocument::fromJson(QByteArray(raw)).object();\n    lez_multisig_free_string(raw);\n    return obj.value(\"account_id\").toString();\n}''';\
+patched=txt.replace('    s.setValue(\"history/\" + key, h);\n}', '    s.setValue(\"history/\" + key, h);\n}' + impl, 1);\
+open(path,'w').write(patched);\
+print('  patched') if patched != txt else print('  no-op')\
+"; \
+		echo "  ✅ Added: clearHistory + computePda + pdaFromSeed implementations"; \
+	else \
+		echo "  ℹ️  Skipped: lez_multisig_compute_pda already present"; \
+	fi
+	@echo "🔧 Patching generated LezMultisigBackend.h/.cpp (executeWithAccounts)..."
+	@if ! grep -q 'executeWithAccounts' $(MODULE_SRC)/LezMultisigBackend.h; then \
+		sed -i 's|Q_INVOKABLE QString     pdaFromSeed(const QString\& seedHex) const;|Q_INVOKABLE QString     pdaFromSeed(const QString\& seedHex) const;\n    Q_INVOKABLE void        executeWithAccounts(const QString\& executorId, const QString\& proposalIndex, const QString\& createKey, const QVariantList\& targetAccounts);|' $(MODULE_SRC)/LezMultisigBackend.h; \
+		python3 -c "\
+path='$(MODULE_SRC)/LezMultisigBackend.cpp';\
+txt=open(path).read();\
+impl='''\nvoid LezMultisigBackend::executeWithAccounts(const QString& executorId, const QString& proposalIndex, const QString& createKey, const QVariantList& targetAccounts) {\n    QJsonObject args = baseArgs();\n    args[\"executor\"]        = executorId;\n    args[\"proposal_index\"]  = proposalIndex;\n    args[\"create_key\"]      = normalizeCreateKey(createKey);\n    QJsonArray accts;\n    for (const QVariant& v : targetAccounts) accts.append(QJsonValue::fromVariant(v));\n    args[\"target_accounts\"] = accts;\n    dispatchFfi(\"execute\", [this, args]() {\n        return callFfi(multisig_program_execute, args);\n    });\n}''';\
+anchor='    return obj.value(\"account_id\").toString();\n}';\
+patched=txt.replace(anchor, anchor + impl, 1);\
+open(path,'w').write(patched);\
+print('  patched') if patched != txt else print('  no-op')\
+"; \
+		echo "  ✅ Added: executeWithAccounts"; \
+	else \
+		echo "  ℹ️  Skipped: executeWithAccounts already present"; \
 	fi
 
 generate-module-scaffold: ## First-time: generate ALL files including qml/Main.qml scaffold (overwrites existing QML)
@@ -283,7 +370,7 @@ endif
 
 .PHONY: build-module run-module
 
-build-module: build-ffi generate-module ## Build the Basecamp UI module plugin + standalone preview app
+build-module: build-ffi ## Build the Basecamp UI module plugin + standalone preview app (run generate-module separately to regenerate backend scaffold)
 	@echo "🔨 Building UI module..."
 	$(if $(LOGOS_DESIGN_SYSTEM_DIR),@echo "  Design system: $(LOGOS_DESIGN_SYSTEM_DIR)",@echo "  ⚠️  LOGOS_DESIGN_SYSTEM_DIR not set — Logos.Theme unavailable")
 	$(if $(SPELBOOK_FFI_DIR),@echo "  Spelbook FFI:  $(SPELBOOK_FFI_DIR)",@echo "  ⚠️  SPELBOOK_FFI_DIR not set — spelbook bridge unavailable")

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ endef
 
 SPEL_FW_GIT  := https://github.com/logos-co/spel.git
 SPEL_FW_TAG  := $(shell grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'tag = "\K[^"]+')
+SPEL_FW_REV  := $(shell grep -m1 'git = "https://github.com/logos-co/spel.git"' lez-multisig-ffi/Cargo.toml | grep -oP 'rev = "\K[^"]+')
 IDL_JSON    := lez-multisig-ffi/src/multisig_idl.json
 FFI_RS      := lez-multisig-ffi/src/multisig.rs
 HEADER_H    := lez-multisig-ffi/include/lez_multisig.h
@@ -58,8 +59,11 @@ MODULE_GEN_DIR := /tmp/lez-module-gen
 .PHONY: generate generate-idl generate-ffi generate-header generate-module generate-module-scaffold check-generated install-tools
 
 install-tools: ## Install spel-client-gen + cbindgen (required for generate/generate-header)
-	source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen --locked 2>/dev/null || \
-	cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen
+	$(if $(SPEL_FW_TAG), \
+	  source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen --locked 2>/dev/null || \
+	  cargo install --git $(SPEL_FW_GIT) --tag $(SPEL_FW_TAG) spel-client-gen, \
+	  source ~/.cargo/env && cargo install --git $(SPEL_FW_GIT) --rev $(SPEL_FW_REV) spel-client-gen --locked 2>/dev/null || \
+	  cargo install --git $(SPEL_FW_GIT) --rev $(SPEL_FW_REV) spel-client-gen)
 	source ~/.cargo/env && cargo install cbindgen --version 0.29.2 --locked 2>/dev/null || true
 
 generate-idl: ## Regenerate IDL from Rust annotations in lib.rs

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
 tokio = { version = "1", features = ["full"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,5 +8,5 @@ name = "multisig"
 path = "src/bin/multisig.rs"
 
 [dependencies]
-spel = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }
 tokio = { version = "1", features = ["full"] }

--- a/e2e_tests/Cargo.toml
+++ b/e2e_tests/Cargo.toml
@@ -13,17 +13,17 @@ path = "tests/e2e_member_management.rs"
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-token_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+token_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 risc0-zkvm = "3.0"
 borsh = "1.5"
 tokio = { version = "1", features = ["full"] }
 
 lez-multisig-ffi = { path = "../lez-multisig-ffi" }
 hex = "0.4"
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["client"] }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
 
 
 [lib]

--- a/e2e_tests/tests/e2e_member_management.rs
+++ b/e2e_tests/tests/e2e_member_management.rs
@@ -18,7 +18,7 @@ use nssa::{
 use multisig_core::{Instruction, MultisigState, Proposal, ProposalStatus};
 use lez_multisig_ffi::{compute_multisig_state_pda, compute_proposal_pda};
 use sequencer_service_rpc::{SequencerClient, SequencerClientBuilder, RpcClient as _};
-use common::transaction::NSSATransaction;
+use common::transaction::LeeTransaction;
 
 const BLOCK_WAIT_SECS: u64 = 15;
 
@@ -34,7 +34,7 @@ fn sequencer_client() -> SequencerClient {
 }
 
 async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
-    let response = client.send_transaction(NSSATransaction::Public(tx)).await.expect("Failed to submit tx");
+    let response = client.send_transaction(LeeTransaction::Public(tx)).await.expect("Failed to submit tx");
     let tx_hash = response;
     println!("  tx_hash: {}", hex::encode(tx_hash.0));
 
@@ -61,7 +61,7 @@ async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
 /// Submit a tx that we expect to fail (not get included).
 /// Returns true if it was correctly rejected/not included.
 async fn submit_tx_expect_failure(client: &SequencerClient, tx: PublicTransaction) -> bool {
-    match client.send_transaction(NSSATransaction::Public(tx)).await {
+    match client.send_transaction(LeeTransaction::Public(tx)).await {
         Err(_) => {
             println!("  ✅ Transaction rejected at submission (expected)");
             return true;
@@ -104,7 +104,7 @@ async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Propo
 }
 
 fn deploy_program(bytecode: Vec<u8>) -> (ProgramDeploymentTransaction, nssa::ProgramId) {
-    let program = Program::new(bytecode.clone()).expect("Invalid program");
+    let program = Program::new(bytecode.clone().into()).expect("Invalid program");
     let program_id = program.id();
     let msg = nssa::program_deployment_transaction::Message::new(bytecode);
     (ProgramDeploymentTransaction::new(msg), program_id)
@@ -183,7 +183,7 @@ async fn test_member_management() {
         .unwrap_or_else(|_| panic!("Cannot read multisig binary at '{}'", multisig_path));
     let (deploy_tx, program_id) = deploy_program(multisig_bytecode);
 
-    match client.send_transaction(NSSATransaction::ProgramDeployment(deploy_tx)).await {
+    match client.send_transaction(LeeTransaction::ProgramDeployment(deploy_tx)).await {
         Ok(r) => {
             println!("  Deployed: {}", hex::encode(r.0));
             tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;

--- a/e2e_tests/tests/e2e_multisig.rs
+++ b/e2e_tests/tests/e2e_multisig.rs
@@ -34,7 +34,7 @@ use lez_multisig_ffi::{
     compute_multisig_state_pda, compute_proposal_pda, compute_vault_pda, vault_pda_seed_bytes,
 };
 use sequencer_service_rpc::{SequencerClient, SequencerClientBuilder, RpcClient as _};
-use common::transaction::NSSATransaction;
+use common::transaction::LeeTransaction;
 use token_core::{Instruction as TokenInstruction, TokenHolding};
 
 const BLOCK_WAIT_SECS: u64 = 15;
@@ -51,7 +51,7 @@ fn sequencer_client() -> SequencerClient {
 }
 
 async fn submit_tx(client: &SequencerClient, tx: PublicTransaction) {
-    let response = client.send_transaction(NSSATransaction::Public(tx)).await.expect("Failed to submit tx");
+    let response = client.send_transaction(LeeTransaction::Public(tx)).await.expect("Failed to submit tx");
     let tx_hash = response;
     println!("  tx_hash: {}", hex::encode(tx_hash.0));
 
@@ -135,7 +135,7 @@ async fn get_proposal(client: &SequencerClient, proposal_id: AccountId) -> Propo
 }
 
 fn deploy_program(bytecode: Vec<u8>) -> (ProgramDeploymentTransaction, nssa::ProgramId) {
-    let program = Program::new(bytecode.clone()).expect("Invalid program");
+    let program = Program::new(bytecode.clone().into()).expect("Invalid program");
     let program_id = program.id();
     let msg = nssa::program_deployment_transaction::Message::new(bytecode);
     (ProgramDeploymentTransaction::new(msg), program_id)
@@ -168,7 +168,7 @@ async fn test_multisig_token_transfer() {
 
     // Deploy both (skip if already deployed)
     for (name, tx) in [("token", token_deploy_tx), ("multisig", multisig_deploy_tx)] {
-        match client.send_transaction(NSSATransaction::ProgramDeployment(tx)).await {
+        match client.send_transaction(LeeTransaction::ProgramDeployment(tx)).await {
             Ok(r) => {
                 println!("  {} deployed: {}", name, hex::encode(r.0));
                 tokio::time::sleep(Duration::from_secs(BLOCK_WAIT_SECS)).await;

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }
 serde_json = "1"

--- a/idl-gen/Cargo.toml
+++ b/idl-gen/Cargo.toml
@@ -9,5 +9,5 @@ path = "src/main.rs"
 
 [dependencies]
 multisig_program = { path = "../multisig_program" }
-spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
 serde_json = "1"

--- a/lez-multisig-ffi/Cargo.toml
+++ b/lez-multisig-ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
@@ -19,11 +19,11 @@ hex = "0.4"
 bs58 = "0.5"
 
 # nssa deps for transaction building
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 borsh = "1.5"
 sha2 = "0.10"
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
 risc0-zkvm = { version = "3.0.5", features = ["std"] }

--- a/lez-multisig-ffi/Cargo.toml
+++ b/lez-multisig-ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 multisig_core = { path = "../multisig_core" }
-spel-framework-core = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/lez-multisig-ffi/src/lib.rs
+++ b/lez-multisig-ffi/src/lib.rs
@@ -43,6 +43,26 @@ pub fn compute_vault_pda(program_id: &ProgramId, create_key: &[u8; 32]) -> Accou
     compute_pda_multi(program_id, &[&tag as &dyn ToSeed, create_key])
 }
 
+/// Seed bytes for a named PDA: SHA256(pad32("multisig_vault__") || create_key || purpose).
+/// `purpose` is arbitrary bytes differentiating this PDA from others (e.g. token def ID, label).
+/// Empty purpose gives the same result as `vault_pda_seed_bytes` — the default vault.
+pub fn named_pda_seed_bytes(create_key: &[u8; 32], purpose: &[u8]) -> [u8; 32] {
+    use sha2::{Sha256, Digest};
+    let tag = seed_from_str("multisig_vault__");
+    let mut hasher = Sha256::new();
+    hasher.update(tag);
+    hasher.update(create_key);
+    hasher.update(purpose);
+    hasher.finalize().into()
+}
+
+/// PDA for a named vault: same derivation as the default vault but with an additional
+/// `purpose` discriminator, giving each (multisig, purpose) pair a unique address.
+pub fn compute_named_pda(program_id: &ProgramId, create_key: &[u8; 32], purpose: &[u8]) -> AccountId {
+    let seed = named_pda_seed_bytes(create_key, purpose);
+    nssa_core::account::AccountId::for_public_pda(program_id, &nssa_core::program::PdaSeed::new(seed))
+}
+
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
@@ -153,6 +173,71 @@ pub extern "C" fn lez_multisig_program_id() -> *mut c_char {
     ))
 }
 
+/// Compute a named PDA and its seed for use in proposals.
+///
+/// args_json: {"create_key": hex32, "program_id_hex": hex64, "purpose": "any string"}
+/// `purpose` differentiates PDAs — empty string gives the default vault, any other string
+/// gives a unique PDA for that (multisig, purpose) pair.
+/// Returns: {"pda": "<account_id>", "seed_hex": "<64-hex-chars>"}
+/// Caller must free with lez_multisig_free_string.
+#[no_mangle]
+pub extern "C" fn lez_multisig_compute_pda(args_json: *const c_char) -> *mut c_char {
+    let args = match cstr_to_str(args_json) { Ok(s) => s, Err(e) => return error_str(&e) };
+    let v: serde_json::Value = match serde_json::from_str(args) {
+        Ok(v) => v,
+        Err(e) => return error_str(&format!("json: {}", e)),
+    };
+    let result = (|| -> Result<String, String> {
+        let program_id = multisig_queries::parse_program_id_hex(
+            v["program_id_hex"].as_str().ok_or("missing program_id_hex")?)?;
+        let create_key_hex = v["create_key"].as_str().ok_or("missing create_key")?;
+        let create_key_bytes = hex::decode(create_key_hex.trim_start_matches("0x"))
+            .map_err(|e| format!("create_key hex: {}", e))?;
+        if create_key_bytes.len() != 32 { return Err("create_key must be 32 bytes".into()); }
+        let mut create_key = [0u8; 32];
+        create_key.copy_from_slice(&create_key_bytes);
+        let purpose = v["purpose"].as_str().unwrap_or("").as_bytes().to_vec();
+        let seed = named_pda_seed_bytes(&create_key, &purpose);
+        let pda = compute_named_pda(&program_id, &create_key, &purpose);
+        Ok(serde_json::json!({
+            "pda": pda.to_string(),
+            "seed_hex": hex::encode(seed),
+        }).to_string())
+    })();
+    to_cstring(result.unwrap_or_else(|e| serde_json::json!({"error": e}).to_string()))
+}
+
+/// Given a raw 32-byte PDA seed (as stored in proposal.pda_seeds), compute the
+/// corresponding account ID so the execute flow can reconstruct target_accounts
+/// without needing the original purpose string.
+///
+/// args_json: {"program_id_hex": "<hex64>", "seed_hex": "<hex64>"}
+/// Returns:   {"account_id": "<account_id>"} or {"error": "..."}
+#[no_mangle]
+pub extern "C" fn lez_multisig_pda_from_seed(args_json: *const c_char) -> *mut c_char {
+    let args = match cstr_to_str(args_json) { Ok(s) => s, Err(e) => return error_str(&e) };
+    let v: serde_json::Value = match serde_json::from_str(args) {
+        Ok(v) => v,
+        Err(e) => return error_str(&format!("json: {}", e)),
+    };
+    let result = (|| -> Result<String, String> {
+        let program_id = multisig_queries::parse_program_id_hex(
+            v["program_id_hex"].as_str().ok_or("missing program_id_hex")?)?;
+        let seed_hex = v["seed_hex"].as_str().ok_or("missing seed_hex")?;
+        let seed_bytes = hex::decode(seed_hex.trim_start_matches("0x"))
+            .map_err(|e| format!("seed_hex: {}", e))?;
+        if seed_bytes.len() != 32 { return Err("seed_hex must be 32 bytes (64 hex chars)".into()); }
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&seed_bytes);
+        let account_id = nssa_core::account::AccountId::for_public_pda(
+            &program_id,
+            &nssa_core::program::PdaSeed::new(seed),
+        );
+        Ok(serde_json::json!({ "account_id": account_id.to_string() }).to_string())
+    })();
+    to_cstring(result.unwrap_or_else(|e| serde_json::json!({"error": e}).to_string()))
+}
+
 // ── Read-only helpers (not in IDL) ───────────────────────────────────────────
 
 /// List all proposals for a multisig.
@@ -183,7 +268,7 @@ mod multisig_queries {
     use wallet::WalletCore;
     use serde_json::{Value, json};
     use multisig_core::{MultisigState, Proposal};
-    use crate::{compute_proposal_pda, compute_multisig_state_pda};
+    use crate::{compute_proposal_pda, compute_multisig_state_pda, compute_vault_pda};
     use nssa_core::account::AccountId;
 
     fn load_wallet(v: &Value) -> Result<WalletCore, String> {
@@ -193,13 +278,13 @@ mod multisig_queries {
         WalletCore::from_env().map_err(|e| format!("wallet: {}", e))
     }
 
-    fn parse_program_id_hex(s: &str) -> Result<nssa_core::program::ProgramId, String> {
+    pub(super) fn parse_program_id_hex(s: &str) -> Result<nssa_core::program::ProgramId, String> {
         let s = s.trim_start_matches("0x");
         if s.len() != 64 { return Err(format!("program_id must be 64 hex chars")); }
         let bytes = hex::decode(s).map_err(|e| format!("hex: {}", e))?;
         let mut pid = [0u32; 8];
         for (i, chunk) in bytes.chunks(4).enumerate() {
-            pid[i] = u32::from_le_bytes(chunk.try_into().unwrap());
+            pid[i] = u32::from_be_bytes(chunk.try_into().unwrap());
         }
         Ok(pid)
     }
@@ -270,6 +355,7 @@ mod multisig_queries {
             let mut create_key = [0u8; 32];
             create_key.copy_from_slice(&create_key_bytes);
             let ms_id = compute_multisig_state_pda(&program_id, &create_key);
+            let vault_id = compute_vault_pda(&program_id, &create_key);
             match fetch_borsh::<MultisigState>(&wallet, ms_id).await? {
                 Some(state) => {
                     let members: Vec<String> = state.members.iter()
@@ -282,6 +368,7 @@ mod multisig_queries {
                         "members": members,
                         "transaction_index": state.transaction_index,
                         "multisig_state_id": ms_id.to_string(),
+                        "vault_id": vault_id.to_string(),
                     }).to_string())
                 }
                 None => Err("multisig_state not found".to_string()),

--- a/lez-multisig-ffi/src/lib.rs
+++ b/lez-multisig-ffi/src/lib.rs
@@ -273,7 +273,7 @@ mod multisig_queries {
 
     fn load_wallet(v: &Value) -> Result<WalletCore, String> {
         if let Some(p) = v["wallet_path"].as_str() {
-            std::env::set_var("NSSA_WALLET_HOME_DIR", p);
+            std::env::set_var("LEE_WALLET_HOME_DIR", p);
         }
         WalletCore::from_env().map_err(|e| format!("wallet: {}", e))
     }

--- a/lez-multisig-module/CMakeLists.txt
+++ b/lez-multisig-module/CMakeLists.txt
@@ -65,13 +65,44 @@ else()
     message(STATUS "Spelbook FFI: not configured (set -DSPELBOOK_FFI_DIR=...)")
 endif()
 
+# ── Logos CPP SDK (optional — provides StorageModule for native IDL fetch) ──
+# Set LOGOS_CPP_SDK_INC to the directory containing logos_api.h, logos_types.h, etc.
+# e.g.: cmake -DLOGOS_CPP_SDK_INC=/path/to/logos-cpp-sdk/cpp ..
+# Workspace default is auto-detected from repos/logos-cpp-sdk/cpp/.
+set(LOGOS_CPP_SDK_INC "" CACHE PATH "logos-cpp-sdk include dir (contains logos_api.h)")
+if("${LOGOS_CPP_SDK_INC}" STREQUAL "")
+    set(_LOGOS_SDK_WORKSPACE "$ENV{HOME}/devel/github.com/logos-co/logos-workspace/repos/logos-cpp-sdk/cpp")
+    if(EXISTS "${_LOGOS_SDK_WORKSPACE}/logos_api.h")
+        set(LOGOS_CPP_SDK_INC "${_LOGOS_SDK_WORKSPACE}")
+    endif()
+endif()
+if(NOT "${LOGOS_CPP_SDK_INC}" STREQUAL "")
+    message(STATUS "Logos CPP SDK include: ${LOGOS_CPP_SDK_INC} — StorageModule enabled for plugin")
+else()
+    message(STATUS "Logos CPP SDK include: not configured (set -DLOGOS_CPP_SDK_INC=...) — StorageModule disabled")
+endif()
+# LOGOS_STORAGE_AVAILABLE is set per-target (plugin only) below to avoid
+# linking storage_module_api.cpp into LezMultisigApp where logos_sdk is absent.
+
+set(_STORAGE_API_SRC vendor/storage_module_api/storage_module_api.cpp)
+set(_STORAGE_API_INC vendor/storage_module_api)
+
 # ── Plugin (loaded by Basecamp) ────────────────────────────────────────────
 add_library(LezMultisigPlugin SHARED
     src/LezMultisigBackend.cpp
     src/LezMultisigPlugin.cpp
     src/LezMultisigCodec.h        # header-only; listed for IDE visibility
     src/LezSpelbookBridge.h       # header-only; listed for IDE visibility
+    src/LezStorageBridge.h        # header-only; listed for IDE visibility
 )
+
+# storage_module_api.cpp added only to the plugin (.so) — undefined LogosAPI symbols
+# are resolved at runtime from Basecamp's process. The standalone app can't link them.
+if(NOT "${LOGOS_CPP_SDK_INC}" STREQUAL "")
+    target_sources(LezMultisigPlugin PRIVATE ${_STORAGE_API_SRC})
+    target_compile_definitions(LezMultisigPlugin PRIVATE LOGOS_STORAGE_AVAILABLE)
+    target_include_directories(LezMultisigPlugin PRIVATE ${_STORAGE_API_INC} ${LOGOS_CPP_SDK_INC} src)
+endif()
 
 # Resource name "lez_multisig_qml" must match Q_INIT_RESOURCE(lez_multisig_qml) in LezMultisigPlugin.cpp
 qt_add_resources(LezMultisigPlugin "lez_multisig_qml"
@@ -95,7 +126,15 @@ add_executable(LezMultisigApp
     src/LezMultisigPlugin.cpp
     src/LezMultisigCodec.h        # header-only; listed for IDE visibility
     src/LezSpelbookBridge.h       # header-only; listed for IDE visibility
+    src/LezStorageBridge.h        # header-only; listed for IDE visibility
 )
+
+# App only needs include dirs so LezStorageBridge.h compiles (storage disabled
+# at runtime — no LOGOS_STORAGE_AVAILABLE, no storage_module_api.cpp linked).
+target_include_directories(LezMultisigApp PRIVATE src)
+if(NOT "${LOGOS_CPP_SDK_INC}" STREQUAL "")
+    target_include_directories(LezMultisigApp PRIVATE ${_STORAGE_API_INC} ${LOGOS_CPP_SDK_INC})
+endif()
 
 # Same resource name as the plugin so Q_INIT_RESOURCE resolves in both targets
 qt_add_resources(LezMultisigApp "lez_multisig_qml"

--- a/lez-multisig-module/qml/Main.qml
+++ b/lez-multisig-module/qml/Main.qml
@@ -11,6 +11,7 @@ Item {
     // ── Navigation ────────────────────────────────────────────────────────────
     // 0 = dashboard, 1 = detail, 2 = settings
     property int page: 0
+    property int detailTab: 0    // 0=Proposals, 1=Vault
 
     // ── Multisig state ────────────────────────────────────────────────────────
     property var knownMultisigs: []      // [{createKey, label}]
@@ -19,7 +20,14 @@ Item {
     property int _fetchTarget: 0
     property int _fetchNext: 0
     property string _multisigIdl: ""    // lazily loaded from codec.getMultisigIdl()
-    property string _storageUrl: ""     // Logos Storage URL (Codex) — for IDL fetching via spelbook
+    property int _busyElapsed: 0
+
+    Timer {
+        id: busyTimer
+        interval: 1000; repeat: true; running: backend.busy
+        onTriggered: _busyElapsed++
+        onRunningChanged: if (!running) _busyElapsed = 0
+    }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
     function u8ArrayToHex(arr) {
@@ -44,6 +52,29 @@ Item {
         return s
     }
 
+    function base58ToHex(s) {
+        s = s.replace(/^(Public|Private)\//, "")
+        var alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+        var bytes = []
+        var i
+        for (i = 0; i < 32; i++) bytes.push(0)
+        for (i = 0; i < s.length; i++) {
+            var carry = alpha.indexOf(s[i])
+            if (carry < 0) return ""
+            for (var j = 31; j >= 0; j--) {
+                carry += bytes[j] * 58
+                bytes[j] = carry & 0xff
+                carry = carry >> 8
+            }
+        }
+        var hex = ""
+        for (i = 0; i < 32; i++) {
+            var b = bytes[i]
+            hex += ((b >> 4) & 0xf).toString(16) + (b & 0xf).toString(16)
+        }
+        return hex
+    }
+
     function shortHex(hex) {
         if (!hex || hex.length <= 16) return hex || ""
         return hex.slice(0, 8) + "…" + hex.slice(-8)
@@ -66,6 +97,17 @@ Item {
     function approvalCount(p) { return p["approved"] ? p["approved"].length : 0 }
     function rejectCount(p)   { return p["rejected"] ? p["rejected"].length : 0 }
 
+    function describeConfigAction(ca) {
+        if (!ca) return ""
+        var keys = Object.keys(ca)
+        if (keys.length === 0) return JSON.stringify(ca)
+        var type = keys[0]
+        if (type === "AddMember")        return "Add member: " + shortHex(ca[type]["new_member"] || "")
+        if (type === "RemoveMember")     return "Remove member: " + shortHex(ca[type]["member"] || "")
+        if (type === "ChangeThreshold")  return "Change threshold to " + ca[type]["new_threshold"]
+        return JSON.stringify(ca)
+    }
+
     function threshold() {
         var s = backend.multisigState
         return s ? (s["threshold"] || 0) : 0
@@ -79,13 +121,18 @@ Item {
     function membersHex() {
         var s = backend.multisigState
         if (!s || !s["members"]) return []
-        return s["members"].map(function(m) { return u8ArrayToHex(m) })
+        return s["members"].map(function(m) {
+            if (typeof m === "string") return m
+            return u8ArrayToHex(m)
+        })
     }
 
     // ── Persistence ───────────────────────────────────────────────────────────
     function loadKnownMultisigs() {
-        var raw = backend.fieldHistory("multisig_create_keys")
-        var labelsRaw = backend.fieldHistory("multisig_labels")
+        var rawArr = JSON.parse(JSON.stringify(backend.fieldHistory("multisig_create_keys")))
+        var raw = (rawArr && rawArr.length > 0) ? rawArr[0] : ""
+        var labelsArr = JSON.parse(JSON.stringify(backend.fieldHistory("multisig_labels")))
+        var labelsRaw = (labelsArr && labelsArr.length > 0) ? labelsArr[0] : ""
         var labels = {}
         try { if (labelsRaw) labels = JSON.parse(labelsRaw) } catch(e) {}
         var keys = raw ? raw.split(",").filter(function(k) { return k.length > 0 }) : []
@@ -98,7 +145,8 @@ Item {
             backend.saveHistory("multisig_create_keys", existing.concat([createKey]).join(","))
         }
         if (label) {
-            var labelsRaw = backend.fieldHistory("multisig_labels")
+            var labelsArr = JSON.parse(JSON.stringify(backend.fieldHistory("multisig_labels")))
+            var labelsRaw = (labelsArr && labelsArr.length > 0) ? labelsArr[0] : ""
             var labels = {}
             try { if (labelsRaw) labels = JSON.parse(labelsRaw) } catch(e) {}
             labels[createKey] = label
@@ -111,7 +159,8 @@ Item {
         var keys = knownMultisigs.map(function(m) { return m.createKey })
                                  .filter(function(k) { return k !== createKey })
         backend.saveHistory("multisig_create_keys", keys.join(","))
-        var labelsRaw = backend.fieldHistory("multisig_labels")
+        var labelsArr = JSON.parse(JSON.stringify(backend.fieldHistory("multisig_labels")))
+        var labelsRaw = (labelsArr && labelsArr.length > 0) ? labelsArr[0] : ""
         var labels = {}
         try { if (labelsRaw) labels = JSON.parse(labelsRaw) } catch(e) {}
         delete labels[createKey]
@@ -126,6 +175,7 @@ Item {
         _fetchNext = 0
         _fetchTarget = 0
         page = 1
+        detailTab = 0
         backend.fetchMultisigState(createKey)
     }
 
@@ -139,8 +189,6 @@ Item {
         loadKnownMultisigs()
         backend.listAccounts()
         _multisigIdl = codec.getMultisigIdl()
-        var rawStorageUrl = backend.fieldHistory("storage_url")
-        if (rawStorageUrl) _storageUrl = rawStorageUrl
     }
 
     // ── Backend connections ───────────────────────────────────────────────────
@@ -159,17 +207,25 @@ Item {
         function onProposalChanged() {
             var p = backend.proposal
             if (!p || Object.keys(p).length === 0) return
-            var idx = parseInt(p["index"]) || _fetchNext
+            var fetchIdx = _fetchNext  // PDA index used to fetch = actual on-chain slot
+            // Tag the proposal with its PDA index (differs from p["index"] because the
+            // on-chain program uses next_proposal_index() which increments before assigning)
+            var entry = {}
+            var keys = Object.keys(p)
+            for (var i = 0; i < keys.length; i++) entry[keys[i]] = p[keys[i]]
+            entry["_pda_index"] = fetchIdx
             var arr = proposals.slice()
-            arr[idx] = p
+            arr[fetchIdx] = entry
             proposals = arr
-            _fetchNext = idx + 1
+            _fetchNext = fetchIdx + 1
             fetchNextProposal()
         }
 
         function onOperationSuccess(operation, txHash) {
             toast.show("✓ " + operation + (txHash ? " · " + txHash.slice(0, 12) + "…" : ""), Theme.palette.success)
-            if (activeCreateKey) backend.fetchMultisigState(activeCreateKey)
+            // Qt.callLater defers until after m_busy is cleared in C++ (m_busy is still true
+            // when this signal fires — it's set to false only after handleFfiResult returns)
+            Qt.callLater(function() { if (activeCreateKey) backend.fetchMultisigState(activeCreateKey) })
         }
 
         function onOperationError(operation, error) {
@@ -177,6 +233,105 @@ Item {
         }
 
         function onWalletAccountsChanged() {}
+    }
+
+    // ── Reusable account field with history + wallet picker ───────────────────
+    component AccountField: Item {
+        id: _af
+        property alias text: _afField.text
+        property alias placeholderText: _afField.placeholderText
+        property string historyKey: ""
+        property bool showCurrentMembers: false
+        Layout.fillWidth: true
+        implicitHeight: _afField.implicitHeight
+
+        property var _hist: []
+        property var _accts: []
+        property var _members: []
+
+        LogosTextField {
+            id: _afField
+            anchors { left: parent.left; right: _afBtn.left; top: parent.top; bottom: parent.bottom }
+            anchors.rightMargin: 4
+        }
+
+        Rectangle {
+            id: _afBtn
+            anchors.right: parent.right; anchors.verticalCenter: parent.verticalCenter
+            width: 28; height: 28; radius: 6
+            color: _afBtnHover.containsMouse ? Theme.palette.backgroundSecondary : Theme.palette.backgroundElevated
+            border.color: Theme.palette.border
+
+            Text { anchors.centerIn: parent; text: "▾"; color: Theme.palette.textMuted; font.pixelSize: 14 }
+
+            MouseArea {
+                id: _afBtnHover
+                anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    _af._hist = JSON.parse(JSON.stringify(backend.fieldHistory(_af.historyKey)))
+                    _af._accts = JSON.parse(JSON.stringify(backend.walletAccounts))
+                    _af._members = _af.showCurrentMembers ? membersHex() : []
+                    _afPop.open()
+                }
+            }
+
+            Popup {
+                id: _afPop
+                y: _afBtn.height + 2; x: -(_afField.width + 4)
+                width: _afField.width + _afBtn.width + 4
+                padding: 0
+                background: Rectangle { color: Theme.palette.backgroundElevated; border.color: Theme.palette.border; radius: 6 }
+                contentItem: Column {
+                    width: parent.width; spacing: 0; topPadding: 4; bottomPadding: 4
+
+                    Text { visible: _af._hist.length > 0; text: "RECENT"; color: Theme.palette.textMuted; font.pixelSize: 10; font.bold: true; font.family: Theme.typography.publicSans; leftPadding: 10; topPadding: 2; bottomPadding: 2; width: parent.width }
+                    Repeater {
+                        model: _af._hist
+                        delegate: Rectangle {
+                            required property string modelData
+                            width: parent.width; height: 34
+                            color: _mh.containsMouse ? Theme.palette.backgroundSecondary : "transparent"
+                            Text { anchors.verticalCenter: parent.verticalCenter; x: 10; width: parent.width - 10; text: modelData; color: Theme.palette.text; elide: Text.ElideMiddle; font.pixelSize: 12; font.family: Theme.typography.publicSans }
+                            MouseArea { id: _mh; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                                onClicked: { _afField.text = modelData; _afPop.close() } }
+                        }
+                    }
+
+                    Rectangle { width: parent.width; height: 1; color: Theme.palette.border; visible: _af._hist.length > 0 && (_af._members.length > 0 || _af._accts.length > 0) }
+
+                    Text { visible: _af._members.length > 0; text: "MEMBERS"; color: Theme.palette.textMuted; font.pixelSize: 10; font.bold: true; font.family: Theme.typography.publicSans; leftPadding: 10; topPadding: 2; bottomPadding: 2; width: parent.width }
+                    Repeater {
+                        model: _af._members
+                        delegate: Rectangle {
+                            required property string modelData
+                            width: parent.width; height: 34
+                            color: _mm.containsMouse ? Theme.palette.backgroundSecondary : "transparent"
+                            Text { anchors.verticalCenter: parent.verticalCenter; x: 10; width: parent.width - 10; text: modelData; color: Theme.palette.text; elide: Text.ElideMiddle; font.pixelSize: 12; font.family: Theme.typography.publicSans }
+                            MouseArea { id: _mm; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                                onClicked: { _afField.text = modelData; backend.saveHistory(_af.historyKey, modelData); _afPop.close() } }
+                        }
+                    }
+
+                    Rectangle { width: parent.width; height: 1; color: Theme.palette.border; visible: (_af._hist.length > 0 || _af._members.length > 0) && _af._accts.length > 0 }
+
+                    Text { visible: _af._accts.length > 0; text: "WALLET"; color: Theme.palette.textMuted; font.pixelSize: 10; font.bold: true; font.family: Theme.typography.publicSans; leftPadding: 10; topPadding: 2; bottomPadding: 2; width: parent.width }
+                    Repeater {
+                        model: _af._accts
+                        delegate: Rectangle {
+                            required property var modelData
+                            width: parent.width; height: 34
+                            color: _mw.containsMouse ? Theme.palette.backgroundSecondary : "transparent"
+                            Text { anchors.verticalCenter: parent.verticalCenter; x: 10; width: parent.width - 10; text: modelData.id + (modelData.label ? "  [" + modelData.label + "]" : ""); color: Theme.palette.text; elide: Text.ElideMiddle; font.pixelSize: 12; font.family: Theme.typography.publicSans }
+                            MouseArea { id: _mw; anchors.fill: parent; hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                                onClicked: { _afField.text = modelData.id; backend.saveHistory(_af.historyKey, modelData.id); _afPop.close() } }
+                        }
+                    }
+
+                    Item { visible: _af._hist.length === 0 && _af._accts.length === 0 && _af._members.length === 0; height: 36; width: parent.width
+                        Text { anchors.centerIn: parent; text: "No accounts or history yet."; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans } }
+                }
+            }
+        }
     }
 
     // ── Root background ───────────────────────────────────────────────────────
@@ -230,21 +385,32 @@ Item {
                 }
 
                 // Busy indicator
-                Row {
-                    visible: backend.busy; spacing: 4
-                    Repeater {
-                        model: 3
-                        Rectangle {
-                            width: 5; height: 5; radius: 2.5
-                            color: Theme.palette.primary
-                            SequentialAnimation on opacity {
-                                running: backend.busy; loops: Animation.Infinite
-                                PauseAnimation  { duration: index * 180 }
-                                NumberAnimation { to: 1.0; duration: 180 }
-                                NumberAnimation { to: 0.2; duration: 180 }
-                                PauseAnimation  { duration: (2 - index) * 180 }
+                RowLayout {
+                    visible: backend.busy; spacing: 8
+                    Row {
+                        spacing: 4
+                        Layout.alignment: Qt.AlignVCenter
+                        Repeater {
+                            model: 3
+                            Rectangle {
+                                width: 5; height: 5; radius: 2.5
+                                color: Theme.palette.primary
+                                SequentialAnimation on opacity {
+                                    running: backend.busy; loops: Animation.Infinite
+                                    PauseAnimation  { duration: index * 180 }
+                                    NumberAnimation { to: 1.0; duration: 180 }
+                                    NumberAnimation { to: 0.2; duration: 180 }
+                                    PauseAnimation  { duration: (2 - index) * 180 }
+                                }
                             }
                         }
+                    }
+                    Text {
+                        visible: _busyElapsed >= 4
+                        Layout.alignment: Qt.AlignVCenter
+                        text: "Confirming… " + _busyElapsed + "s"
+                        color: Theme.palette.textMuted
+                        font.pixelSize: 11; font.family: Theme.typography.publicSans
                     }
                 }
 
@@ -431,119 +597,591 @@ Item {
                 ColumnLayout {
                     anchors.fill: parent; spacing: 0
 
-                    // Multisig header card
+                    // Multisig header card — only the threshold row; everything else is in the outer
+                    // ColumnLayout so we never depend on implicitHeight of dynamically-visible children.
                     Rectangle {
                         Layout.fillWidth: true
-                        height: headerCol.implicitHeight + 24
+                        height: 56
                         color: Theme.palette.backgroundSecondary
                         border.color: Theme.palette.border
 
-                        ColumnLayout {
-                            id: headerCol
-                            anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
-                            spacing: 8
-
-                            RowLayout {
+                        RowLayout {
+                            anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter; margins: 16 }
+                            Text {
+                                text: Object.keys(backend.multisigState).length > 0
+                                      ? (threshold() + " of " + memberCount() + " threshold")
+                                      : "Loading…"
+                                color: Object.keys(backend.multisigState).length > 0 ? Theme.palette.text : Theme.palette.textMuted
+                                font.pixelSize: 15; font.bold: true
+                                font.family: Theme.typography.publicSans
                                 Layout.fillWidth: true
-                                Text {
-                                    text: threshold() + " of " + memberCount() + " threshold"
-                                    color: Theme.palette.text
-                                    font.pixelSize: 15; font.bold: true
-                                    font.family: Theme.typography.publicSans
-                                    Layout.fillWidth: true
-                                    visible: Object.keys(backend.multisigState).length > 0
-                                }
-                                Text {
-                                    visible: Object.keys(backend.multisigState).length === 0
-                                    text: "Loading…"
-                                    color: Theme.palette.textMuted
-                                    font.pixelSize: 14; font.family: Theme.typography.publicSans
-                                    Layout.fillWidth: true
-                                }
-                                Rectangle {
-                                    width: 28; height: 28; radius: Theme.spacing.radiusSmall
-                                    color: refArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
-                                    Text { anchors.centerIn: parent; text: "↺"; color: Theme.palette.textMuted; font.pixelSize: 16 }
-                                    MouseArea {
-                                        id: refArea; anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor; hoverEnabled: true
-                                        onClicked: openMultisig(activeCreateKey)
-                                    }
+                            }
+                            Rectangle {
+                                width: 28; height: 28; implicitHeight: 28; radius: Theme.spacing.radiusSmall
+                                color: refArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                Text { anchors.centerIn: parent; text: "↺"; color: Theme.palette.textMuted; font.pixelSize: 16 }
+                                MouseArea {
+                                    id: refArea; anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                    onClicked: openMultisig(activeCreateKey)
                                 }
                             }
+                        }
+                    }
 
-                            // Members chips
-                            Flow {
-                                Layout.fillWidth: true; spacing: 6
-                                Repeater {
-                                    model: membersHex()
-                                    Rectangle {
-                                        height: 22; width: memberChip.implicitWidth + 16; radius: 11
-                                        color: Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.12)
-                                        border.color: Theme.palette.primary
-                                        Text {
-                                            id: memberChip; anchors.centerIn: parent
-                                            text: shortHex(modelData)
-                                            color: Theme.palette.primary
-                                            font.pixelSize: 11; font.family: Theme.typography.publicSans
-                                        }
-                                    }
-                                }
+                    // Create key row
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: 16; Layout.rightMargin: 16
+                        Layout.preferredHeight: 24
+                        visible: !!activeCreateKey
+                        spacing: 6
+                        Text {
+                            text: "Key:"
+                            color: Theme.palette.textMuted
+                            font.pixelSize: 11; font.family: Theme.typography.publicSans
+                        }
+                        Text {
+                            text: shortHex(activeCreateKey)
+                            color: Theme.palette.text
+                            font.pixelSize: 11; font.family: "monospace"
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                        }
+                        Rectangle {
+                            width: 44; height: 20; implicitHeight: 20; radius: Theme.spacing.radiusLarge
+                            color: pdaCopyArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                            border.color: Theme.palette.border
+                            Text {
+                                anchors.centerIn: parent
+                                text: "Copy"; color: Theme.palette.textMuted
+                                font.pixelSize: 10; font.family: Theme.typography.publicSans
                             }
+                            MouseArea {
+                                id: pdaCopyArea; anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                onClicked: { clipHelper.copyText(activeCreateKey); toast.show("Copied key") }
+                            }
+                        }
+                    }
 
-                            // Actions row
-                            RowLayout {
-                                Layout.fillWidth: true
-                                Text {
-                                    text: proposals.filter(function(p){ return p && proposalStatus(p) === "Pending" }).length + " pending  ·  " +
-                                          (parseInt(backend.multisigState["transaction_index"]) || 0) + " total"
-                                    color: Theme.palette.textMuted
-                                    font.pixelSize: Theme.typography.secondaryText
-                                    font.family: Theme.typography.publicSans
-                                    Layout.fillWidth: true
-                                }
-                                Rectangle {
-                                    width: newPropText.implicitWidth + 16; height: 26; radius: Theme.spacing.radiusLarge
-                                    color: newPropArea.containsMouse ? Theme.palette.primaryHover : Theme.palette.primary
+                    // Members chips (outside header card — Flow.implicitHeight is 0 until layout, so keeping
+                    // it here avoids the header Rectangle sizing itself too small)
+                    Flow {
+                        Layout.fillWidth: true
+                        Layout.leftMargin: 16; Layout.rightMargin: 16
+                        Layout.topMargin: 6; Layout.bottomMargin: 2
+                        spacing: 6
+                        visible: membersHex().length > 0
+                        Repeater {
+                            model: membersHex()
+                            Rectangle {
+                                property string memberHex: modelData
+                                width: chipRow.implicitWidth + 18
+                                height: 22; implicitHeight: 22
+                                radius: 11
+                                color: chipArea.containsMouse
+                                    ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.22)
+                                    : Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.12)
+                                border.color: Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.3)
+                                Row {
+                                    id: chipRow
+                                    anchors.centerIn: parent
+                                    spacing: 4
                                     Text {
-                                        id: newPropText; anchors.centerIn: parent
-                                        text: "New Proposal"; color: Theme.palette.text
-                                        font.pixelSize: 12; font.family: Theme.typography.publicSans
+                                        text: (index + 1)
+                                        color: Theme.palette.primary
+                                        font.pixelSize: 9; font.bold: true
+                                        font.family: Theme.typography.publicSans
+                                        anchors.verticalCenter: parent.verticalCenter
                                     }
-                                    MouseArea {
-                                        id: newPropArea; anchors.fill: parent
-                                        cursorShape: Qt.PointingHandCursor; hoverEnabled: true
-                                        onClicked: proposeDialog.open()
+                                    Text {
+                                        text: shortHex(memberHex)
+                                        color: Theme.palette.text
+                                        font.pixelSize: 10; font.family: "monospace"
+                                        anchors.verticalCenter: parent.verticalCenter
                                     }
                                 }
-                                Repeater {
-                                    model: ["Add Member", "Remove Member", "Change Threshold"]
-                                    Rectangle {
-                                        width: govText.implicitWidth + 16; height: 26; radius: Theme.spacing.radiusLarge
-                                        color: govArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
-                                        border.color: Theme.palette.border
-                                        Text {
-                                            id: govText; anchors.centerIn: parent
-                                            text: modelData; color: Theme.palette.textMuted
-                                            font.pixelSize: 12; font.family: Theme.typography.publicSans
-                                        }
-                                        MouseArea {
-                                            id: govArea; anchors.fill: parent
-                                            cursorShape: Qt.PointingHandCursor; hoverEnabled: true
-                                            onClicked: {
-                                                if (modelData === "Add Member")       addMemberDialog.open()
-                                                else if (modelData === "Remove Member")   removeMemberDialog.open()
-                                                else if (modelData === "Change Threshold") changeThresholdDialog.open()
-                                            }
-                                        }
+                                MouseArea {
+                                    id: chipArea; anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                    onClicked: { clipHelper.copyText(memberHex); toast.show("Copied member ID") }
+                                }
+                            }
+                        }
+                    }
+
+                    // Actions bar (outside header card so height never clips it)
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 38
+                        Layout.leftMargin: 16; Layout.rightMargin: 16
+                        // Tab switcher
+                        Repeater {
+                            model: ["Proposals", "Vault"]
+                            Rectangle {
+                                width: detailTabLabel.implicitWidth + 16; height: 26; implicitHeight: 26
+                                radius: Theme.spacing.radiusLarge
+                                color: root.detailTab === index
+                                    ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.15)
+                                    : "transparent"
+                                border.color: root.detailTab === index ? Theme.palette.primary : "transparent"
+                                Text {
+                                    id: detailTabLabel
+                                    anchors.centerIn: parent
+                                    text: modelData
+                                    color: root.detailTab === index ? Theme.palette.primary : Theme.palette.textMuted
+                                    font.pixelSize: 12; font.family: Theme.typography.publicSans
+                                }
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: root.detailTab = index
+                                }
+                            }
+                        }
+                        Item { Layout.fillWidth: true }
+                        // Proposals-tab actions
+                        Rectangle {
+                            visible: root.detailTab === 0
+                            width: newPropText.implicitWidth + 16; height: 26; implicitHeight: 26; radius: Theme.spacing.radiusLarge
+                            color: newPropArea.containsMouse ? Theme.palette.primaryHover : Theme.palette.primary
+                            Text {
+                                id: newPropText; anchors.centerIn: parent
+                                text: "New Proposal"; color: Theme.palette.text
+                                font.pixelSize: 12; font.family: Theme.typography.publicSans
+                            }
+                            MouseArea {
+                                id: newPropArea; anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                onClicked: proposeDialog.open()
+                            }
+                        }
+                        Repeater {
+                            model: root.detailTab === 0 ? ["Add Member", "Remove Member", "Change Threshold"] : []
+                            Rectangle {
+                                width: govText.implicitWidth + 16; height: 26; implicitHeight: 26; radius: Theme.spacing.radiusLarge
+                                color: govArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                border.color: Theme.palette.border
+                                Text {
+                                    id: govText; anchors.centerIn: parent
+                                    text: modelData; color: Theme.palette.textMuted
+                                    font.pixelSize: 12; font.family: Theme.typography.publicSans
+                                }
+                                MouseArea {
+                                    id: govArea; anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                    onClicked: {
+                                        if (modelData === "Add Member")        addMemberDialog.open()
+                                        else if (modelData === "Remove Member")    removeMemberDialog.open()
+                                        else if (modelData === "Change Threshold") changeThresholdDialog.open()
                                     }
                                 }
                             }
                         }
                     }
 
+                    // ── Vault / PDA manager tab ───────────────────────────────
+                    ScrollView {
+                        visible: root.detailTab === 1
+                        Layout.fillWidth: true; Layout.fillHeight: true; clip: true; contentWidth: availableWidth
+
+                        ColumnLayout {
+                            width: parent.parent.width; spacing: 0
+
+                            Item { height: 16; Layout.fillWidth: true }
+
+                            // Multisig state account card
+                            Rectangle {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 16; Layout.rightMargin: 16
+                                radius: Theme.spacing.radiusLarge
+                                color: Theme.palette.backgroundSecondary
+                                border.color: Theme.palette.border
+                                height: vaultStateCol.implicitHeight + 24
+
+                                ColumnLayout {
+                                    id: vaultStateCol
+                                    anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
+                                    spacing: 6
+
+                                    Text {
+                                        text: "Multisig state account"
+                                        color: Theme.palette.textMuted
+                                        font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                    }
+                                    Text {
+                                        text: "Stores the multisig configuration (members, threshold, proposals). Not for funding."
+                                        color: Theme.palette.textMuted
+                                        font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                        wrapMode: Text.WordWrap
+                                        Layout.fillWidth: true
+                                    }
+                                    RowLayout {
+                                        Layout.fillWidth: true; spacing: 8
+                                        Text {
+                                            text: backend.multisigState["multisig_state_id"] || "—"
+                                            color: Theme.palette.text
+                                            font.pixelSize: 11; font.family: "monospace"
+                                            elide: Text.ElideMiddle
+                                            Layout.fillWidth: true
+                                        }
+                                        Rectangle {
+                                            width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                            color: stateIdCopyArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                            border.color: Theme.palette.border
+                                            Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                            MouseArea {
+                                                id: stateIdCopyArea; anchors.fill: parent
+                                                cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                onClicked: {
+                                                    clipHelper.copyText(backend.multisigState["multisig_state_id"] || "")
+                                                    toast.show("Copied state account ID")
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Item { height: 16; Layout.fillWidth: true }
+
+                            // ── PDA manager ───────────────────────────────────
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 16; Layout.rightMargin: 16
+                                spacing: 10
+
+                                // section header
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    Text {
+                                        text: "Vault PDAs"
+                                        color: Theme.palette.text
+                                        font.pixelSize: 13; font.bold: true; font.family: Theme.typography.publicSans
+                                    }
+                                    Item { Layout.fillWidth: true }
+                                    Text {
+                                        text: "Named accounts this multisig controls as a signer"
+                                        color: Theme.palette.textMuted
+                                        font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                    }
+                                }
+
+                                // Default vault (always first)
+                                Rectangle {
+                                    Layout.fillWidth: true
+                                    radius: Theme.spacing.radiusLarge
+                                    color: Theme.palette.backgroundSecondary
+                                    border.color: Theme.palette.primary
+                                    height: defaultVaultCol.implicitHeight + 24
+
+                                    ColumnLayout {
+                                        id: defaultVaultCol
+                                        anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
+                                        spacing: 6
+
+                                        RowLayout {
+                                            spacing: 8
+                                            Text {
+                                                text: "Default vault"
+                                                color: Theme.palette.primary
+                                                font.pixelSize: 12; font.bold: true; font.family: Theme.typography.publicSans
+                                            }
+                                            Rectangle {
+                                                width: defaultVaultChip.implicitWidth + 10; height: 18; radius: 9
+                                                color: Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.15)
+                                                Text { id: defaultVaultChip; anchors.centerIn: parent; text: "Fund this"; color: Theme.palette.primary; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                            }
+                                        }
+                                        Text {
+                                            text: "purpose: (empty string) — general-purpose multisig signer"
+                                            color: Theme.palette.textMuted; font.pixelSize: 10; font.family: "monospace"
+                                            Layout.fillWidth: true
+                                        }
+                                        RowLayout {
+                                            Layout.fillWidth: true; spacing: 8
+                                            Text {
+                                                text: backend.multisigState["vault_id"] || "—"
+                                                color: Theme.palette.text; font.pixelSize: 11; font.family: "monospace"
+                                                elide: Text.ElideMiddle; Layout.fillWidth: true
+                                            }
+                                            Rectangle {
+                                                width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                                color: defAddrCopy.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                                border.color: Theme.palette.border
+                                                Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                MouseArea { id: defAddrCopy; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                    onClicked: { clipHelper.copyText(backend.multisigState["vault_id"] || ""); toast.show("Copied vault address") } }
+                                            }
+                                        }
+                                        // Default vault seed (from FFI)
+                                        RowLayout {
+                                            Layout.fillWidth: true; spacing: 8
+                                            property var _seed: root.activeCreateKey ? backend.computePda(root.activeCreateKey, "") : ({})
+                                            Text {
+                                                text: "seed:"
+                                                color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans
+                                            }
+                                            Text {
+                                                text: parent._seed["seed_hex"] || "—"
+                                                color: Theme.palette.textMuted; font.pixelSize: 10; font.family: "monospace"
+                                                elide: Text.ElideMiddle; Layout.fillWidth: true
+                                            }
+                                            Rectangle {
+                                                width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                                color: defSeedCopy.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                                border.color: Theme.palette.border
+                                                Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                MouseArea { id: defSeedCopy; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                    onClicked: { clipHelper.copyText(parent.parent._seed["seed_hex"] || ""); toast.show("Copied seed hex") } }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Named vaults (user-derived)
+                                Repeater {
+                                    id: namedPdaRepeater
+                                    model: root.activeCreateKey ? backend.fieldHistory("pdas:" + root.activeCreateKey) : []
+                                    delegate: Rectangle {
+                                        required property string modelData
+                                        required property int index
+                                        property var pdaData: { try { return JSON.parse(modelData) } catch(e) { return {} } }
+                                        Layout.fillWidth: true
+                                        radius: Theme.spacing.radiusLarge
+                                        color: Theme.palette.backgroundSecondary
+                                        border.color: Theme.palette.border
+                                        height: namedPdaCol.implicitHeight + 24
+
+                                        ColumnLayout {
+                                            id: namedPdaCol
+                                            anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
+                                            spacing: 6
+
+                                            RowLayout {
+                                                spacing: 8
+                                                Text {
+                                                    text: pdaData["label"] || ("Vault " + (index + 1))
+                                                    color: Theme.palette.text
+                                                    font.pixelSize: 12; font.bold: true; font.family: Theme.typography.publicSans
+                                                }
+                                                Item { Layout.fillWidth: true }
+                                                Rectangle {
+                                                    width: delPdaArea.implicitWidth + 16; height: 20; radius: 10
+                                                    color: delPdaArea2.containsMouse ? Qt.rgba(1,0,0,0.12) : "transparent"
+                                                    border.color: Theme.palette.border
+                                                    Text { id: delPdaArea; anchors.centerIn: parent; text: "Remove"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                    MouseArea {
+                                                        id: delPdaArea2; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                        onClicked: {
+                                                            var list = backend.fieldHistory("pdas:" + root.activeCreateKey)
+                                                            list.splice(index, 1)
+                                                            backend.clearHistory("pdas:" + root.activeCreateKey)
+                                                            proposeDialog._vaultEpoch++
+                                                            // re-add in reverse so prepend preserves order
+                                                            for (var ri = list.length - 1; ri >= 0; ri--)
+                                                                backend.saveHistory("pdas:" + root.activeCreateKey, list[ri])
+                                                            namedPdaRepeater.model = backend.fieldHistory("pdas:" + root.activeCreateKey)
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            Text {
+                                                text: "purpose: " + (pdaData["purpose"] || "(empty)")
+                                                color: Theme.palette.textMuted; font.pixelSize: 10; font.family: "monospace"
+                                                Layout.fillWidth: true; elide: Text.ElideRight
+                                            }
+                                            RowLayout {
+                                                Layout.fillWidth: true; spacing: 8
+                                                Text {
+                                                    text: pdaData["pda"] || "—"
+                                                    color: Theme.palette.text; font.pixelSize: 11; font.family: "monospace"
+                                                    elide: Text.ElideMiddle; Layout.fillWidth: true
+                                                }
+                                                Rectangle {
+                                                    width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                                    color: namedAddrCopy.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                                    border.color: Theme.palette.border
+                                                    Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                    MouseArea { id: namedAddrCopy; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                        onClicked: { clipHelper.copyText(pdaData["pda"] || ""); toast.show("Copied vault address") } }
+                                                }
+                                            }
+                                            RowLayout {
+                                                Layout.fillWidth: true; spacing: 8
+                                                Text { text: "seed:"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                Text {
+                                                    text: pdaData["seed_hex"] || "—"
+                                                    color: Theme.palette.textMuted; font.pixelSize: 10; font.family: "monospace"
+                                                    elide: Text.ElideMiddle; Layout.fillWidth: true
+                                                }
+                                                Rectangle {
+                                                    width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                                    color: namedSeedCopy.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                                    border.color: Theme.palette.border
+                                                    Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                    MouseArea { id: namedSeedCopy; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                        onClicked: { clipHelper.copyText(pdaData["seed_hex"] || ""); toast.show("Copied seed hex") } }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Derive new named vault
+                                Rectangle {
+                                    Layout.fillWidth: true
+                                    radius: Theme.spacing.radiusLarge
+                                    color: "transparent"
+                                    border.color: Theme.palette.border
+                                    border.width: 1
+                                    height: deriveCol.implicitHeight + 24
+
+                                    ColumnLayout {
+                                        id: deriveCol
+                                        anchors { left: parent.left; right: parent.right; top: parent.top; margins: 16 }
+                                        spacing: 8
+
+                                        Text {
+                                            text: "Derive a named vault"
+                                            color: Theme.palette.text; font.pixelSize: 12; font.bold: true; font.family: Theme.typography.publicSans
+                                        }
+                                        Text {
+                                            text: "Each purpose string produces a unique PDA — use the token definition ID, a label, or any differentiator."
+                                            color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                            wrapMode: Text.WordWrap; Layout.fillWidth: true
+                                        }
+                                        RowLayout {
+                                            Layout.fillWidth: true; spacing: 8
+                                            TextField {
+                                                id: pdaPurposeInput
+                                                placeholderText: "Purpose (e.g. token-A holding, 0xabc123…)"
+                                                Layout.fillWidth: true
+                                                font.pixelSize: 12; font.family: "monospace"
+                                                background: Rectangle { radius: Theme.spacing.radiusSmall; color: Theme.palette.background; border.color: Theme.palette.border; border.width: 1 }
+                                                color: Theme.palette.text
+                                                Keys.onReturnPressed: derivePdaBtn.clicked()
+                                            }
+                                            Rectangle {
+                                                id: derivePdaBtn
+                                                signal clicked()
+                                                width: deriveBtnLabel.implicitWidth + 24; height: 36; radius: Theme.spacing.radiusSmall
+                                                color: deriveBtnArea.containsMouse ? Qt.lighter(Theme.palette.primary, 1.1) : Theme.palette.primary
+                                                Text { id: deriveBtnLabel; anchors.centerIn: parent; text: "Derive"; color: "white"; font.pixelSize: 12; font.bold: true; font.family: Theme.typography.publicSans }
+                                                MouseArea { id: deriveBtnArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true; onClicked: derivePdaBtn.clicked() }
+                                                onClicked: {
+                                                    if (!root.activeCreateKey) { toast.show("No active multisig"); return }
+                                                    var purpose = pdaPurposeInput.text.trim()
+                                                    var result = backend.computePda(root.activeCreateKey, purpose)
+                                                    if (result["error"]) { toast.show("Error: " + result["error"]); return }
+                                                    var entry = JSON.stringify({
+                                                        label: purpose || "vault",
+                                                        purpose: purpose,
+                                                        pda: result["pda"],
+                                                        seed_hex: result["seed_hex"]
+                                                    })
+                                                    backend.saveHistory("pdas:" + root.activeCreateKey, entry)
+                                                    namedPdaRepeater.model = backend.fieldHistory("pdas:" + root.activeCreateKey)
+                                                    proposeDialog._vaultEpoch++
+                                                    pdaPurposeInput.text = ""
+                                                    toast.show("Vault derived: " + result["pda"].slice(0, 14) + "…")
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Item { height: 16; Layout.fillWidth: true }
+
+                            // PDA seeds from proposals (existing, kept for reference)
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 16; Layout.rightMargin: 16
+                                spacing: 8
+                                visible: {
+                                    var seeds = []
+                                    for (var i = 0; i < proposals.length; i++) {
+                                        var p = proposals[i]
+                                        if (p && p["pda_seeds"]) {
+                                            var ps = p["pda_seeds"]
+                                            for (var j = 0; j < ps.length; j++) {
+                                                var s = ps[j]
+                                                if (s && seeds.indexOf(s) === -1) seeds.push(s)
+                                            }
+                                        }
+                                    }
+                                    return seeds.length > 0
+                                }
+
+                                Text {
+                                    text: "PDA seeds used in proposals"
+                                    color: Theme.palette.textMuted
+                                    font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                }
+
+                                Repeater {
+                                    model: {
+                                        var seeds = []
+                                        for (var i = 0; i < proposals.length; i++) {
+                                            var p = proposals[i]
+                                            if (p && p["pda_seeds"]) {
+                                                var ps = p["pda_seeds"]
+                                                for (var j = 0; j < ps.length; j++) {
+                                                    var s = ps[j]
+                                                    if (s && seeds.indexOf(s) === -1) seeds.push(s)
+                                                }
+                                            }
+                                        }
+                                        return seeds
+                                    }
+                                    delegate: Rectangle {
+                                        Layout.fillWidth: true
+                                        radius: Theme.spacing.radiusSmall
+                                        color: Theme.palette.backgroundSecondary
+                                        border.color: Theme.palette.border
+                                        height: seedRow.implicitHeight + 16
+
+                                        RowLayout {
+                                            id: seedRow
+                                            anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter; margins: 12 }
+                                            spacing: 8
+                                            Text {
+                                                text: "Seed"
+                                                color: Theme.palette.textMuted
+                                                font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                            }
+                                            Text {
+                                                text: modelData
+                                                color: Theme.palette.text
+                                                font.pixelSize: 10; font.family: "monospace"
+                                                elide: Text.ElideMiddle
+                                                Layout.fillWidth: true
+                                            }
+                                            Rectangle {
+                                                width: 44; height: 22; radius: Theme.spacing.radiusLarge
+                                                color: seedCopyArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                                border.color: Theme.palette.border
+                                                Text { anchors.centerIn: parent; text: "Copy"; color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans }
+                                                MouseArea {
+                                                    id: seedCopyArea; anchors.fill: parent
+                                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                                    onClicked: { clipHelper.copyText(modelData); toast.show("Copied seed") }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            Item { height: 40; Layout.fillWidth: true }
+                        }
+                    }
+
                     // Proposals list
                     ScrollView {
+                        visible: root.detailTab === 0
                         Layout.fillWidth: true; Layout.fillHeight: true; clip: true; contentWidth: availableWidth
 
                         ColumnLayout {
@@ -575,7 +1213,7 @@ Item {
                                     property int pApproved: approvalCount(pdata)
                                     property int pRejected: rejectCount(pdata)
                                     property int pThreshold: threshold()
-                                    property bool pExecutable: pStatus === "Pending" && pApproved >= pThreshold
+                                    property bool pExecutable: pStatus === "Active" && pApproved >= pThreshold
                                     property var _decoded: null
                                     property string _decodeError: ""
 
@@ -615,17 +1253,10 @@ Item {
                                             _decodeError = (result.error || "decode failed") + " · program not in spelbook cache"
                                             return
                                         }
-                                        if (!_storageUrl) {
-                                            _decoded = null
-                                            _decodeError = "program in spelbook (idl_cid: " + entry["idl_cid"].slice(0, 12) + "…) — set Storage URL in Settings to fetch IDL"
-                                            return
+                                        var externalIdl = storage.fetchIdl(entry["idl_cid"])
+                                        if (!externalIdl) {
+                                            _decoded = null; _decodeError = "IDL fetch failed for cid: " + entry["idl_cid"].slice(0, 12) + "…"; return
                                         }
-                                        var idlFetchStr = spelbook.fetchIdl(_storageUrl, entry["idl_cid"])
-                                        var idlFetch = JSON.parse(idlFetchStr)
-                                        if (!idlFetch.success) {
-                                            _decoded = null; _decodeError = "IDL fetch failed: " + (idlFetch.error || "unknown"); return
-                                        }
-                                        var externalIdl = JSON.stringify(idlFetch.idl)
                                         var resultStr2 = codec.decodeInstruction(externalIdl, wordsJson)
                                         var result2 = JSON.parse(resultStr2)
                                         if (result2.success) { _decoded = result2.result; _decodeError = "" }
@@ -663,13 +1294,13 @@ Item {
                                         // Config action or target program
                                         Text {
                                             property var ca: pdata["config_action"]
-                                            text: ca ? JSON.stringify(ca)
+                                            text: ca ? describeConfigAction(ca)
                                                  : (pdata["target_program_id"]
                                                      ? "Target: " + shortHex(u32ArrayToHex(pdata["target_program_id"]))
                                                      : "")
                                             visible: text !== ""
                                             color: Theme.palette.textMuted
-                                            font.pixelSize: 11; font.family: "monospace"
+                                            font.pixelSize: 11; font.family: Theme.typography.publicSans
                                             elide: Text.ElideRight; Layout.fillWidth: true
                                         }
 
@@ -714,9 +1345,9 @@ Item {
                                             }
                                         }
 
-                                        // Decode button (only for proposals with instruction data)
+                                        // Decode button (only for proposals with instruction data, not config proposals)
                                         Rectangle {
-                                            visible: !!pdata["target_instruction_data"]
+                                            visible: !!pdata["target_instruction_data"] && !pdata["config_action"]
                                             width: decodeText.implicitWidth + 14; height: 22
                                             radius: Theme.spacing.radiusSmall
                                             color: decodeArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
@@ -749,26 +1380,55 @@ Item {
                                             }
                                         }
 
-                                        // Approval count
-                                        Text {
-                                            text: pApproved + " / " + pThreshold + " approvals" +
-                                                  (pRejected > 0 ? "  ·  " + pRejected + " rejected" : "")
-                                            color: Theme.palette.textMuted
-                                            font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                        // Approval count + who approved
+                                        RowLayout {
+                                            Layout.fillWidth: true
+                                            spacing: 6
+                                            Text {
+                                                text: pApproved + " / " + pThreshold + " approvals" +
+                                                      (pRejected > 0 ? "  ·  " + pRejected + " rejected" : "")
+                                                color: Theme.palette.textMuted
+                                                font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                            }
+                                            Repeater {
+                                                model: pdata["approved"] || []
+                                                Rectangle {
+                                                    property string approverId: {
+                                                        var a = modelData
+                                                        if (typeof a === "string") return a
+                                                        if (Array.isArray(a)) return u8ArrayToHex(a)
+                                                        return JSON.stringify(a)
+                                                    }
+                                                    width: approverText.implicitWidth + 10
+                                                    height: 16; implicitHeight: 16; radius: 8
+                                                    color: Qt.rgba(Theme.palette.success.r, Theme.palette.success.g, Theme.palette.success.b, 0.15)
+                                                    border.color: Qt.rgba(Theme.palette.success.r, Theme.palette.success.g, Theme.palette.success.b, 0.4)
+                                                    Text {
+                                                        id: approverText
+                                                        anchors.centerIn: parent
+                                                        text: shortHex(parent.approverId)
+                                                        color: Theme.palette.success
+                                                        font.pixelSize: 9; font.family: "monospace"
+                                                    }
+                                                    MouseArea {
+                                                        anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                                                        onClicked: { clipHelper.copyText(parent.approverId); toast.show("Copied approver ID") }
+                                                    }
+                                                }
+                                            }
+                                            Item { Layout.fillWidth: true }
                                         }
 
-                                        // Action buttons (Pending proposals only)
+                                        // Action buttons (Active proposals only)
                                         RowLayout {
-                                            visible: pStatus === "Pending"
+                                            visible: pStatus === "Active"
                                             spacing: 8
 
                                             Repeater {
-                                                model: pExecutable
-                                                    ? [{ label: "Approve", col: Theme.palette.success },
-                                                       { label: "Reject",  col: Theme.palette.error   },
-                                                       { label: "Execute", col: Theme.palette.primary  }]
-                                                    : [{ label: "Approve", col: Theme.palette.success  },
-                                                       { label: "Reject",  col: Theme.palette.error    }]
+                                                model: [
+                                                    { label: "Approve", col: Theme.palette.success },
+                                                    { label: "Reject",  col: Theme.palette.error   }
+                                                ]
                                                 Rectangle {
                                                     width: actionText.implicitWidth + 16; height: 26
                                                     radius: Theme.spacing.radiusSmall
@@ -786,12 +1446,44 @@ Item {
                                                         id: actionArea; anchors.fill: parent
                                                         cursorShape: Qt.PointingHandCursor; hoverEnabled: true
                                                         property string propAction: modelData.label
-                                                        property int propIdx: parseInt(pdata["index"]) || index
+                                                        property int propIdx: pdata["_pda_index"] !== undefined ? parseInt(pdata["_pda_index"]) : (parseInt(pdata["index"]) || index)
                                                         onClicked: {
                                                             accountPicker.action = propAction
                                                             accountPicker.proposalIndex = propIdx
+                                                            accountPicker.proposalData = pdata
                                                             accountPicker.open()
                                                         }
+                                                    }
+                                                }
+                                            }
+
+                                            // Execute — always visible, enabled only when threshold met
+                                            Rectangle {
+                                                width: executeText.implicitWidth + 16; height: 26
+                                                radius: Theme.spacing.radiusSmall
+                                                color: pExecutable
+                                                    ? (executeArea.containsMouse
+                                                        ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.25)
+                                                        : Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.10))
+                                                    : Theme.palette.backgroundElevated
+                                                border.color: pExecutable ? Theme.palette.primary : Theme.palette.border
+                                                Text {
+                                                    id: executeText; anchors.centerIn: parent
+                                                    text: "Execute"
+                                                    color: pExecutable ? Theme.palette.primary : Theme.palette.textMuted
+                                                    font.pixelSize: 12; font.family: Theme.typography.publicSans
+                                                }
+                                                MouseArea {
+                                                    id: executeArea; anchors.fill: parent
+                                                    cursorShape: pExecutable ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                                    hoverEnabled: true
+                                                    property int propIdx: pdata["_pda_index"] !== undefined ? parseInt(pdata["_pda_index"]) : (parseInt(pdata["index"]) || index)
+                                                    onClicked: {
+                                                        if (!pExecutable) return
+                                                        accountPicker.action = "Execute"
+                                                        accountPicker.proposalIndex = propIdx
+                                                        accountPicker.proposalData = pdata
+                                                        accountPicker.open()
                                                     }
                                                 }
                                             }
@@ -828,19 +1520,37 @@ Item {
                         // Settings fields (using plain TextField + Theme styling for onEditingFinished support)
                         Repeater {
                             model: [
-                                { label: "Wallet Path",      getter: function(){ return backend.walletPath },    setter: function(v){ backend.setWalletPath(v) } },
-                                { label: "Sequencer URL",    getter: function(){ return backend.sequencerUrl },  setter: function(v){ backend.setSequencerUrl(v) } },
-                                { label: "Program ID (hex)", getter: function(){ return backend.programIdHex }, setter: function(v){ backend.setProgramIdHex(v) } },
-                                { label: "Storage URL (Codex)", getter: function(){ return root._storageUrl },
-                                  setter: function(v){ root._storageUrl = v; backend.saveHistory("storage_url", v) } }
+                                { label: "Wallet Path",      getter: function(){ return backend.walletPath },    setter: function(v){ backend.setWalletPath(v) },    copyable: false },
+                                { label: "Sequencer URL",    getter: function(){ return backend.sequencerUrl },  setter: function(v){ backend.setSequencerUrl(v) },  copyable: false },
+                                { label: "Program ID (hex)", getter: function(){ return backend.programIdHex },  setter: function(v){ backend.setProgramIdHex(v) },  copyable: true  }
                             ]
                             ColumnLayout {
                                 Layout.fillWidth: true; Layout.leftMargin: 24; Layout.rightMargin: 24; spacing: 4
-                                Text {
-                                    text: modelData.label
-                                    color: Theme.palette.textMuted
-                                    font.pixelSize: Theme.typography.secondaryText
-                                    font.family: Theme.typography.publicSans
+                                RowLayout {
+                                    Layout.fillWidth: true; spacing: 6
+                                    Text {
+                                        text: modelData.label
+                                        color: Theme.palette.textMuted
+                                        font.pixelSize: Theme.typography.secondaryText
+                                        font.family: Theme.typography.publicSans
+                                        Layout.fillWidth: true
+                                    }
+                                    Rectangle {
+                                        visible: modelData.copyable
+                                        width: 44; height: 20; radius: Theme.spacing.radiusLarge
+                                        color: sfCopyArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                        border.color: Theme.palette.border
+                                        Text {
+                                            anchors.centerIn: parent
+                                            text: "Copy"
+                                            color: Theme.palette.textMuted
+                                            font.pixelSize: 10; font.family: Theme.typography.publicSans
+                                        }
+                                        MouseArea {
+                                            id: sfCopyArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                            onClicked: { clipHelper.copyText(modelData.getter()); toast.show("Copied!") }
+                                        }
+                                    }
                                 }
                                 TextField {
                                     Layout.fillWidth: true
@@ -950,6 +1660,89 @@ Item {
                                     font.pixelSize: 12; font.family: "monospace"
                                     Layout.fillWidth: true
                                 }
+                                Rectangle {
+                                    width: 44; height: 20; radius: Theme.spacing.radiusLarge
+                                    color: accCopyArea.containsMouse ? Theme.palette.backgroundMuted : "transparent"
+                                    border.color: Theme.palette.border
+                                    Text {
+                                        anchors.centerIn: parent
+                                        text: "Copy"
+                                        color: Theme.palette.textMuted
+                                        font.pixelSize: 10; font.family: Theme.typography.publicSans
+                                    }
+                                    MouseArea {
+                                        id: accCopyArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                        onClicked: { clipHelper.copyText(modelData["id"] || ""); toast.show("Copied account ID") }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true; Layout.leftMargin: 24; Layout.rightMargin: 24
+                            height: 1; color: Theme.palette.border
+                        }
+
+                        // Create Account
+                        Text {
+                            text: "Create Account"
+                            color: Theme.palette.text
+                            font.pixelSize: 14; font.bold: true
+                            font.family: Theme.typography.publicSans
+                            Layout.leftMargin: 24
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true; Layout.leftMargin: 24; Layout.rightMargin: 24; spacing: 8
+
+                            TextField {
+                                id: newAccountLabel
+                                Layout.fillWidth: true
+                                placeholderText: "Label (optional)"
+                                color: Theme.palette.text
+                                placeholderTextColor: Theme.palette.textPlaceholder
+                                background: Rectangle {
+                                    color: Theme.palette.background
+                                    border.color: Theme.palette.border
+                                    radius: Theme.spacing.radiusSmall
+                                }
+                                Keys.onReturnPressed: createAccountBtn.clicked()
+                            }
+
+                            Rectangle {
+                                id: createAccountBtn
+                                width: createAccountBtnText.implicitWidth + 20; height: 36
+                                radius: Theme.spacing.radiusLarge
+                                color: backend.busy ? Theme.palette.backgroundMuted
+                                     : createAccountBtnArea.containsMouse ? Theme.palette.primaryHover
+                                     : Theme.palette.primary
+                                signal clicked()
+                                onClicked: {
+                                    backend.createAccount(newAccountLabel.text)
+                                    newAccountLabel.text = ""
+                                }
+                                Text {
+                                    id: createAccountBtnText; anchors.centerIn: parent
+                                    text: backend.busy ? "Creating…" : "Create"
+                                    color: Theme.palette.text
+                                    font.pixelSize: 13; font.family: Theme.typography.publicSans
+                                }
+                                MouseArea {
+                                    id: createAccountBtnArea; anchors.fill: parent
+                                    cursorShape: backend.busy ? Qt.ArrowCursor : Qt.PointingHandCursor
+                                    hoverEnabled: true; enabled: !backend.busy
+                                    onClicked: createAccountBtn.clicked()
+                                }
+                            }
+                        }
+
+                        Connections {
+                            target: backend
+                            function onOperationSuccess(op, result) {
+                                if (op === "create_account") toast.show("Account created: " + result.slice(0, 12) + "…")
+                            }
+                            function onOperationError(op, err) {
+                                if (op === "create_account") toast.show("Error: " + err, Theme.palette.error)
                             }
                         }
 
@@ -1001,10 +1794,11 @@ Item {
         title: "Watch Multisig"
         modal: true; anchors.centerIn: parent
         width: Math.min(420, parent.width - 48)
+        contentHeight: watchContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: watchDialog.title; color: Theme.palette.text
@@ -1013,6 +1807,7 @@ Item {
         }
 
         ColumnLayout {
+            id: watchContent
             width: parent.width; spacing: 12
 
             Text { text: "Create key (unique seed)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
@@ -1028,7 +1823,7 @@ Item {
         }
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton {
                 text: "Cancel"
@@ -1063,10 +1858,11 @@ Item {
         title: "Create Multisig"
         modal: true; anchors.centerIn: parent
         width: Math.min(480, parent.width - 48)
+        contentHeight: createContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: createDialog.title; color: Theme.palette.text
@@ -1075,6 +1871,7 @@ Item {
         }
 
         ColumnLayout {
+            id: createContent
             width: parent.width; spacing: 10
 
             Text { text: "Create key (unique seed)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
@@ -1102,7 +1899,7 @@ Item {
         }
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton {
                 text: "Cancel"
@@ -1140,6 +1937,7 @@ Item {
         title: "New Proposal"
         modal: true; anchors.centerIn: parent
         width: Math.min(540, parent.width - 48)
+        contentHeight: Math.min(proposeContent.implicitHeight, parent.height - 160)
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         // 0 = raw words mode, 1 = encode-from-IDL mode
@@ -1148,17 +1946,66 @@ Item {
         property string _encodePreview: ""  // "N words: [0, 1000, …]"
         property var _spelResults: []
         property string _spelQuery: ""
+        property var _parsedInstructions: []
+        property string _selectedIx: ""
+        property var _argValues: ({})
+        property var _accountValues: []   // [{isAuth: bool, seed: string}] indexed by account
+        property string _selectedPresetLabel: ""  // tracks last-clicked builtin chip for program ID persistence
+        property int _vaultEpoch: 0      // bumped on open + on vault save/remove → vaultList re-evaluates
+        onOpened: { _vaultEpoch++; pTargetProgram.text = "" }
+        property var _selectedIxObj: {
+            var sel = _selectedIx
+            var ixs = _parsedInstructions
+            if (!sel) return null
+            for (var i = 0; i < ixs.length; i++)
+                if (ixs[i] && ixs[i].name === sel) return ixs[i]
+            return null
+        }
+        readonly property var _builtinIdls: [
+            { label: "AMM", json: '{"version":"0.1.0","name":"amm","instructions":[{"name":"new_definition","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false},{"name":"pool_definition_lp","writable":false,"signer":false,"init":false},{"name":"lp_lock_holding","writable":false,"signer":false,"init":false},{"name":"user_holding_a","writable":false,"signer":false,"init":false},{"name":"user_holding_b","writable":false,"signer":false,"init":false},{"name":"user_holding_lp","writable":false,"signer":false,"init":false}],"args":[{"name":"token_a_amount","type":"u128"},{"name":"token_b_amount","type":"u128"},{"name":"fees","type":"u128"},{"name":"deadline","type":"u64"}]},{"name":"add_liquidity","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false},{"name":"pool_definition_lp","writable":false,"signer":false,"init":false},{"name":"user_holding_a","writable":false,"signer":false,"init":false},{"name":"user_holding_b","writable":false,"signer":false,"init":false},{"name":"user_holding_lp","writable":false,"signer":false,"init":false}],"args":[{"name":"min_amount_liquidity","type":"u128"},{"name":"max_amount_to_add_token_a","type":"u128"},{"name":"max_amount_to_add_token_b","type":"u128"},{"name":"deadline","type":"u64"}]},{"name":"remove_liquidity","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false},{"name":"pool_definition_lp","writable":false,"signer":false,"init":false},{"name":"user_holding_a","writable":false,"signer":false,"init":false},{"name":"user_holding_b","writable":false,"signer":false,"init":false},{"name":"user_holding_lp","writable":false,"signer":false,"init":false}],"args":[{"name":"remove_liquidity_amount","type":"u128"},{"name":"min_amount_to_remove_token_a","type":"u128"},{"name":"min_amount_to_remove_token_b","type":"u128"},{"name":"deadline","type":"u64"}]},{"name":"swap_exact_input","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false},{"name":"user_holding_a","writable":false,"signer":false,"init":false},{"name":"user_holding_b","writable":false,"signer":false,"init":false}],"args":[{"name":"swap_amount_in","type":"u128"},{"name":"min_amount_out","type":"u128"},{"name":"token_definition_id_in","type":"account_id"},{"name":"deadline","type":"u64"}]},{"name":"swap_exact_output","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false},{"name":"user_holding_a","writable":false,"signer":false,"init":false},{"name":"user_holding_b","writable":false,"signer":false,"init":false}],"args":[{"name":"exact_amount_out","type":"u128"},{"name":"max_amount_in","type":"u128"},{"name":"token_definition_id_in","type":"account_id"},{"name":"deadline","type":"u64"}]},{"name":"sync_reserves","accounts":[{"name":"pool","writable":false,"signer":false,"init":false},{"name":"vault_a","writable":false,"signer":false,"init":false},{"name":"vault_b","writable":false,"signer":false,"init":false}],"args":[]}]}' },
+            { label: "ATA", json: '{"version":"0.1.0","name":"ata","instructions":[{"name":"create","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"token_definition","writable":false,"signer":false,"init":false},{"name":"ata_account","writable":false,"signer":false,"init":false}],"args":[{"name":"token_program_id","type":"program_id"}]},{"name":"transfer","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"sender_ata","writable":false,"signer":false,"init":false},{"name":"recipient","writable":false,"signer":false,"init":false}],"args":[{"name":"token_program_id","type":"program_id"},{"name":"amount","type":"u128"}]},{"name":"burn","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"holder_ata","writable":false,"signer":false,"init":false},{"name":"token_definition","writable":false,"signer":false,"init":false}],"args":[{"name":"token_program_id","type":"program_id"},{"name":"amount","type":"u128"}]}]}' },
+            { label: "Stablecoin", json: '{"version":"0.1.0","name":"stablecoin","instructions":[{"name":"open_position","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"position","writable":false,"signer":false,"init":false},{"name":"vault","writable":false,"signer":false,"init":false},{"name":"user_holding","writable":false,"signer":false,"init":false},{"name":"token_definition","writable":false,"signer":false,"init":false}],"args":[{"name":"collateral_amount","type":"u128"}]},{"name":"withdraw_collateral","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"position","writable":false,"signer":false,"init":false},{"name":"vault","writable":false,"signer":false,"init":false},{"name":"destination","writable":false,"signer":false,"init":false}],"args":[{"name":"amount","type":"u128"}]},{"name":"repay_debt","accounts":[{"name":"owner","writable":false,"signer":false,"init":false},{"name":"position","writable":false,"signer":false,"init":false},{"name":"stablecoin_definition","writable":false,"signer":false,"init":false},{"name":"user_stablecoin_holding","writable":false,"signer":false,"init":false}],"args":[{"name":"amount","type":"u128"}]}]}' },
+            { label: "Token", json: '{"name":"token_program","version":"0.1.0","instructions":[{"name":"transfer","accounts":[{"name":"sender_holding","writable":true,"signer":true,"init":false},{"name":"recipient_holding","writable":true,"signer":false,"init":false}],"args":[{"name":"amount_to_transfer","type":"u128"}]},{"name":"new_fungible_definition","accounts":[{"name":"token_definition","writable":true,"signer":false,"init":true},{"name":"token_holding","writable":true,"signer":false,"init":true}],"args":[{"name":"name","type":"string"},{"name":"total_supply","type":"u128"}]},{"name":"new_definition_with_metadata","accounts":[{"name":"token_definition","writable":true,"signer":false,"init":true},{"name":"token_holding","writable":true,"signer":false,"init":true},{"name":"token_metadata","writable":true,"signer":false,"init":true}],"args":[{"name":"new_definition","type":{"defined":"NewTokenDefinition"}},{"name":"metadata","type":{"defined":"NewTokenMetadata"}}]},{"name":"initialize_account","accounts":[{"name":"token_definition","writable":false,"signer":false,"init":false},{"name":"token_holding","writable":true,"signer":false,"init":true}],"args":[]},{"name":"burn","accounts":[{"name":"token_definition","writable":true,"signer":false,"init":false},{"name":"token_holding","writable":true,"signer":true,"init":false}],"args":[{"name":"amount_to_burn","type":"u128"}]},{"name":"mint","accounts":[{"name":"token_definition","writable":true,"signer":true,"init":false},{"name":"token_holding","writable":true,"signer":false,"init":false}],"args":[{"name":"amount_to_mint","type":"u128"}]},{"name":"print_nft","accounts":[{"name":"nft_master_holding","writable":true,"signer":true,"init":false},{"name":"nft_printed_copy","writable":true,"signer":false,"init":true}],"args":[]}]}' },
+            { label: "TWAP Oracle", json: '{"version":"0.1.0","name":"twap_oracle","instructions":[{"name":"noop","accounts":[],"args":[]}]}' }
+        ]
 
         function _runEncode() {
             _encodeError = ""
             _encodePreview = ""
             var idlStr = pIdlJson.text.trim()
-            var ixName = pIxName.text.trim()
-            var argsStr = pArgsJson.text.trim()
-            if (!idlStr || !ixName || !argsStr) {
-                _encodeError = "Fill in IDL, instruction name, and args JSON"
+            var ixName = proposeDialog._selectedIx || pIxName.text.trim()
+
+            if (!idlStr || !ixName) {
+                if (!ixName && _parsedInstructions.length > 0)
+                    _encodeError = "Select an instruction from the list above"
+                else
+                    _encodeError = "Fill in IDL and select an instruction"
                 return false
             }
+
+            var argsStr
+            var ixObj = proposeDialog._selectedIxObj
+            if (ixObj !== null) {
+                var ixArgs = ixObj.args || []
+                if (ixArgs.length === 0) {
+                    argsStr = "{}"
+                } else {
+                    var obj = {}
+                    for (var i = 0; i < ixArgs.length; i++) {
+                        var n = ixArgs[i].name
+                        var v = (_argValues[n] !== undefined) ? _argValues[n] : ""
+                        try { obj[n] = JSON.parse(v) } catch(e) { obj[n] = v }
+                    }
+                    argsStr = JSON.stringify(obj)
+                }
+            } else {
+                argsStr = pArgsJson.text.trim()
+                if (!argsStr) {
+                    _encodeError = "Fill in the args JSON"
+                    return false
+                }
+            }
+
             var resultStr = codec.encodeInstruction(idlStr, ixName, argsStr)
             var result = JSON.parse(resultStr)
             if (!result.success) {
@@ -1173,7 +2020,7 @@ Item {
         }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             RowLayout {
                 anchors { fill: parent; leftMargin: 20; rightMargin: 16 }
                 Text {
@@ -1205,15 +2052,29 @@ Item {
             }
         }
 
-        ColumnLayout {
+        ScrollView {
+            width: parent.width
+            height: parent.height
+            contentWidth: parent.width
+            clip: true
+
+            ColumnLayout {
+            id: proposeContent
             width: parent.width; spacing: 10
 
             // ── Fields common to both modes ────────────────────────────────
             Text { text: "Proposer account ID"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: pProposerId; Layout.fillWidth: true; placeholderText: "your account ID" }
+            AccountField { id: pProposerId; historyKey: "proposer_id"; placeholderText: "your account ID" }
 
             Text { text: "Target program ID (hex)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: pTargetProgram; Layout.fillWidth: true; placeholderText: "64-char hex" }
+            LogosTextField {
+                id: pTargetProgram; Layout.fillWidth: true; placeholderText: "64-char hex"
+                onTextChanged: {
+                    var t = text.trim()
+                    if (proposeDialog._selectedPresetLabel && t.length === 64)
+                        backend.saveHistory("program_id:" + proposeDialog._selectedPresetLabel, t)
+                }
+            }
 
             // ── Raw words mode ─────────────────────────────────────────────
             ColumnLayout {
@@ -1294,7 +2155,8 @@ Item {
                             border.color: spelResultArea.containsMouse ? Theme.palette.primary : Theme.palette.border
 
                             ColumnLayout {
-                                anchors { fill: parent; margins: 8 }; spacing: 2
+                                anchors { fill: parent; margins: 8 }
+                                spacing: 2
                                 Text {
                                     text: (modelData["name"] || "Unknown") + (modelData["version"] ? "  v" + modelData["version"] : "")
                                     color: Theme.palette.text; font.pixelSize: 12; font.bold: true
@@ -1315,19 +2177,16 @@ Item {
                                 onClicked: {
                                     // Populate target program field
                                     pTargetProgram.text = modelData["program_id"] || ""
-                                    // Fetch IDL if cid + storage URL available
+                                    // Fetch IDL via Logos Storage module
                                     var idlCid = modelData["idl_cid"] || ""
-                                    if (idlCid && _storageUrl) {
-                                        var idlStr = spelbook.fetchIdl(_storageUrl, idlCid)
-                                        var idlRes = JSON.parse(idlStr)
-                                        if (idlRes.success) {
-                                            pIdlJson.text = JSON.stringify(idlRes.idl)
+                                    if (idlCid) {
+                                        var idlStr = storage.fetchIdl(idlCid)
+                                        if (idlStr) {
+                                            pIdlJson.text = idlStr
                                             proposeDialog._encodeError = ""
                                         } else {
-                                            proposeDialog._encodeError = "IDL fetch failed: " + (idlRes.error || "unknown")
+                                            proposeDialog._encodeError = "IDL fetch failed for cid: " + idlCid.slice(0, 16) + "…"
                                         }
-                                    } else if (idlCid && !_storageUrl) {
-                                        proposeDialog._encodeError = "IDL cid: " + idlCid.slice(0, 16) + "… — set Storage URL in Settings to fetch"
                                     }
                                     proposeDialog._spelResults = []
                                     pSpelQuery.text = ""
@@ -1342,6 +2201,39 @@ Item {
                     }
                 }
 
+                // Known program IDL quick-select
+                ColumnLayout {
+                    Layout.fillWidth: true; spacing: 4
+                    Text { text: "Known programs"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
+                    Flow {
+                        Layout.fillWidth: true; spacing: 6
+                        Repeater {
+                            model: proposeDialog._builtinIdls
+                            delegate: Rectangle {
+                                height: 26; radius: Theme.spacing.radiusLarge
+                                width: builtinChipText.implicitWidth + 14
+                                color: builtinChipArea.containsMouse ? Theme.palette.backgroundMuted : Theme.palette.background
+                                border.color: Theme.palette.border
+                                Text {
+                                    id: builtinChipText; anchors.centerIn: parent
+                                    text: modelData.label
+                                    color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                }
+                                MouseArea {
+                                    id: builtinChipArea; anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                    onClicked: {
+                                        proposeDialog._selectedPresetLabel = modelData.label
+                                        pIdlJson.text = modelData.json
+                                        var saved = backend.fieldHistory("program_id:" + modelData.label)
+                                        pTargetProgram.text = (saved.length > 0 && saved[0]) ? saved[0] : ""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 Text { text: "Program IDL (paste JSON)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
                 TextArea {
                     id: pIdlJson; Layout.fillWidth: true; implicitHeight: 80
@@ -1353,81 +2245,388 @@ Item {
                         color: Theme.palette.backgroundSecondary
                         border.color: Theme.palette.border; radius: Theme.spacing.radiusSmall
                     }
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true; spacing: 8
-                    ColumnLayout {
-                        Layout.fillWidth: true; spacing: 4
-                        Text { text: "Instruction name"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-                        LogosTextField { id: pIxName; Layout.fillWidth: true; placeholderText: "e.g. transfer_tokens" }
+                    onTextChanged: {
+                        proposeDialog._selectedIx = ""
+                        proposeDialog._argValues = ({})
+                        proposeDialog._accountValues = []
+                        var t = text.trim()
+                        if (!t) { proposeDialog._parsedInstructions = []; return }
+                        try {
+                            var idl = JSON.parse(t)
+                            var ixs = idl["instructions"] || []
+                            proposeDialog._parsedInstructions = ixs.filter(function(ix) { return !!ix["name"] })
+                            if (idl["programId"] && !pTargetProgram.text.trim())
+                                pTargetProgram.text = idl["programId"]
+                        } catch(e) {
+                            proposeDialog._parsedInstructions = []
+                        }
                     }
                 }
 
-                Text { text: "Args (JSON object)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-                TextArea {
-                    id: pArgsJson; Layout.fillWidth: true; implicitHeight: 60
-                    placeholderText: '{"amount": 1000, "recipient": "0x01020304…"}'
-                    color: Theme.palette.text; font.pixelSize: 11; font.family: "monospace"
-                    placeholderTextColor: Theme.palette.textPlaceholder
-                    wrapMode: TextArea.WrapAtWordBoundaryOrAnywhere
-                    background: Rectangle {
-                        color: Theme.palette.backgroundSecondary
-                        border.color: Theme.palette.border; radius: Theme.spacing.radiusSmall
-                    }
-                }
+                ColumnLayout {
+                    Layout.fillWidth: true; spacing: 4
 
-                // Error + Encode button row
-                RowLayout {
-                    Layout.fillWidth: true
-                    Text {
-                        visible: proposeDialog._encodeError !== ""
-                        text: proposeDialog._encodeError
-                        color: Theme.palette.error; font.pixelSize: 10; font.family: Theme.typography.publicSans
-                        wrapMode: Text.WordWrap; Layout.fillWidth: true
-                    }
-                    Item { Layout.fillWidth: true; visible: proposeDialog._encodeError === "" }
-                    Rectangle {
-                        width: encodeText.implicitWidth + 20; height: 32; radius: Theme.spacing.radiusXlarge
-                        color: encodeArea.containsMouse ? Theme.palette.primaryHover : Theme.palette.primary
+                    RowLayout {
+                        Layout.fillWidth: true; spacing: 6
                         Text {
-                            id: encodeText; anchors.centerIn: parent
-                            text: "Encode →"; color: Theme.palette.text
-                            font.pixelSize: 12; font.family: Theme.typography.publicSans
+                            text: "Instruction"
+                            color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                            Layout.fillWidth: true
                         }
-                        MouseArea {
-                            id: encodeArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
-                            onClicked: proposeDialog._runEncode()
+                        Text {
+                            visible: proposeDialog._selectedIx !== ""
+                            text: proposeDialog._selectedIx
+                            color: Theme.palette.primary; font.pixelSize: 11; font.bold: true
+                            font.family: Theme.typography.publicSans
                         }
                     }
+
+                    // Instruction chips — shown when IDL parsed successfully
+                    Flow {
+                        visible: proposeDialog._parsedInstructions.length > 0
+                        Layout.fillWidth: true; spacing: 6
+
+                        Repeater {
+                            model: proposeDialog._parsedInstructions
+                            delegate: Rectangle {
+                                property bool isSelected: modelData.name === proposeDialog._selectedIx
+                                height: 28; radius: Theme.spacing.radiusLarge
+                                width: ixChipText.implicitWidth + 16
+                                color: isSelected ? Theme.palette.primary
+                                    : (ixChipArea.containsMouse ? Theme.palette.backgroundMuted : Theme.palette.background)
+                                border.color: isSelected ? Theme.palette.primary : Theme.palette.border
+
+                                Text {
+                                    id: ixChipText; anchors.centerIn: parent
+                                    text: modelData.name || ""
+                                    color: isSelected ? Theme.palette.text : Theme.palette.textMuted
+                                    font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                }
+                                MouseArea {
+                                    id: ixChipArea; anchors.fill: parent
+                                    cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                                    onClicked: {
+                                        proposeDialog._selectedIx = modelData.name
+                                        proposeDialog._argValues = ({})
+                                        var accts = modelData.accounts || []
+                                        // auto-auth signer accounts and pre-fill with default vault seed
+                                        var defSeed = root.activeCreateKey
+                                            ? (backend.computePda(root.activeCreateKey, "")["seed_hex"] || "")
+                                            : ""
+                                        proposeDialog._accountValues = accts.map(function(a) {
+                                            return {isAuth: !!a.signer, seed: a.signer ? defSeed : ""}
+                                        })
+                                        pAcctCount.text = String(accts.length)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Fallback text field — shown when no IDL or IDL has no instructions
+                    LogosTextField {
+                        id: pIxName
+                        visible: proposeDialog._parsedInstructions.length === 0
+                        Layout.fillWidth: true
+                        placeholderText: "e.g. transfer_tokens"
+                    }
+                }
+
+                // Accounts section — shown when instruction has accounts
+                ColumnLayout {
+                    visible: proposeDialog._selectedIx !== "" &&
+                             proposeDialog._selectedIxObj !== null &&
+                             (proposeDialog._selectedIxObj.accounts || []).length > 0
+                    Layout.fillWidth: true; spacing: 6
+
+                    Text {
+                        text: "Accounts"
+                        color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                    }
+
+                    Repeater {
+                        model: proposeDialog._selectedIxObj ? (proposeDialog._selectedIxObj.accounts || []) : []
+                        delegate: ColumnLayout {
+                            required property var modelData
+                            required property int index
+                            Layout.fillWidth: true; spacing: 4
+
+                            property bool _isAuth: {
+                                var vals = proposeDialog._accountValues
+                                return vals && vals[index] ? vals[index].isAuth : false
+                            }
+
+                            // ── Account row header ────────────────────────────
+                            RowLayout {
+                                Layout.fillWidth: true; spacing: 6
+
+                                Text {
+                                    text: "[" + index + "] " + (modelData.name || "")
+                                    color: Theme.palette.text; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                    Layout.fillWidth: true
+                                }
+
+                                // Badges
+                                Repeater {
+                                    model: [
+                                        {label: "signer",   show: !!modelData.signer,   hi: true },
+                                        {label: "writable", show: !!modelData.writable, hi: false},
+                                        {label: "init",     show: !!modelData.init,     hi: false}
+                                    ]
+                                    delegate: Rectangle {
+                                        required property var modelData
+                                        visible: modelData.show
+                                        height: 16; radius: 8
+                                        width: badgeText.implicitWidth + 10
+                                        color: modelData.hi
+                                            ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.18)
+                                            : Theme.palette.backgroundSecondary
+                                        border.color: modelData.hi ? Theme.palette.primary : Theme.palette.border
+                                        Text {
+                                            id: badgeText; anchors.centerIn: parent
+                                            text: modelData.label
+                                            color: modelData.hi ? Theme.palette.primary : Theme.palette.textMuted
+                                            font.pixelSize: 8; font.family: Theme.typography.publicSans
+                                        }
+                                    }
+                                }
+
+                                // Auth toggle (only for signer accounts)
+                                Rectangle {
+                                    visible: !!modelData.signer
+                                    height: 22; radius: Theme.spacing.radiusLarge
+                                    width: authToggleText.implicitWidth + 12
+                                    color: _isAuth
+                                        ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.20)
+                                        : Theme.palette.background
+                                    border.color: _isAuth ? Theme.palette.primary : Theme.palette.border
+                                    Text {
+                                        id: authToggleText; anchors.centerIn: parent
+                                        text: _isAuth ? "Vault auth" : "External signer"
+                                        color: _isAuth ? Theme.palette.primary : Theme.palette.textMuted
+                                        font.pixelSize: 9; font.family: Theme.typography.publicSans
+                                    }
+                                    MouseArea {
+                                        anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                                        onClicked: {
+                                            var vals = proposeDialog._accountValues.slice()
+                                            if (!vals[index]) return
+                                            vals[index] = {isAuth: !vals[index].isAuth, seed: vals[index].seed}
+                                            proposeDialog._accountValues = vals
+                                        }
+                                    }
+                                }
+                            }
+
+                            // init hint
+                            Text {
+                                visible: !!modelData.init
+                                text: "This account may not exist yet — will be created by the program on execution."
+                                color: Theme.palette.textMuted; font.pixelSize: 9; font.family: Theme.typography.publicSans
+                                wrapMode: Text.WordWrap; Layout.fillWidth: true
+                            }
+
+                            // ── Vault picker (shown when Vault auth is on) ────
+                            ColumnLayout {
+                                visible: _isAuth
+                                Layout.fillWidth: true; spacing: 4
+                                // Capture the outer account index as a named property so nested
+                                // children don't need fragile parent chains.
+                                property int acctIdx: index
+
+                                property var vaultList: {
+                                    var _epoch = proposeDialog._vaultEpoch  // reactive dep → re-evals on open + vault change
+                                    var list = []
+                                    var defRes = root.activeCreateKey
+                                        ? backend.computePda(root.activeCreateKey, "") : {}
+                                    var defSeed = defRes["seed_hex"] || ""
+                                    var defAddr = backend.multisigState["vault_id"] || ""
+                                    if (defSeed) list.push({label: "Default vault", pda: defAddr, seed_hex: defSeed})
+                                    var stored = root.activeCreateKey
+                                        ? backend.fieldHistory("pdas:" + root.activeCreateKey) : []
+                                    for (var k = 0; k < stored.length; k++) {
+                                        try { list.push(JSON.parse(stored[k])) } catch(e) {}
+                                    }
+                                    return list
+                                }
+
+                                Repeater {
+                                    model: parent.vaultList  // parent = vault picker ColumnLayout
+                                    delegate: Rectangle {
+                                        required property var modelData
+                                        required property int index
+                                        property int  _ai:  parent.acctIdx
+                                        property bool _sel: {
+                                            var vals = proposeDialog._accountValues
+                                            return vals && vals[_ai]
+                                                ? vals[_ai].seed === modelData.seed_hex : false
+                                        }
+                                        Layout.fillWidth: true
+                                        height: vpRow.implicitHeight + 10
+                                        radius: Theme.spacing.radiusSmall
+                                        color: _sel
+                                            ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.12)
+                                            : Theme.palette.backgroundSecondary
+                                        border.color: _sel ? Theme.palette.primary : Theme.palette.border
+                                        border.width: _sel ? 2 : 1
+
+                                        MouseArea {
+                                            anchors.fill: parent; cursorShape: Qt.PointingHandCursor
+                                            onClicked: {
+                                                var vals = proposeDialog._accountValues.slice()
+                                                if (!vals[parent._ai]) return
+                                                vals[parent._ai] = {isAuth: true, seed: parent.modelData.seed_hex}
+                                                proposeDialog._accountValues = vals
+                                            }
+                                        }
+
+                                        RowLayout {
+                                            id: vpRow
+                                            anchors { left: parent.left; right: parent.right; verticalCenter: parent.verticalCenter; margins: 10 }
+                                            spacing: 8
+
+                                            // Radio dot
+                                            Rectangle {
+                                                width: 16; height: 16; radius: 8
+                                                color: "transparent"
+                                                border.color: parent.parent._sel ? Theme.palette.primary : Theme.palette.border
+                                                border.width: 2
+                                                Rectangle {
+                                                    anchors.centerIn: parent
+                                                    width: 8; height: 8; radius: 4
+                                                    visible: parent.parent.parent._sel
+                                                    color: Theme.palette.primary
+                                                }
+                                            }
+
+                                            ColumnLayout {
+                                                Layout.fillWidth: true; spacing: 1
+                                                Text {
+                                                    text: modelData.label || "Vault"
+                                                    color: parent.parent.parent._sel ? Theme.palette.primary : Theme.palette.text
+                                                    font.pixelSize: 11; font.bold: parent.parent.parent._sel
+                                                    font.family: Theme.typography.publicSans
+                                                }
+                                                Text {
+                                                    text: (modelData.pda || "").slice(0, 24) + "…"
+                                                    color: Theme.palette.textMuted; font.pixelSize: 9; font.family: "monospace"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Manual seed override
+                                RowLayout {
+                                    Layout.fillWidth: true; spacing: 6
+                                    // parent = vault picker ColumnLayout (has .acctIdx)
+                                    Text { text: "or seed:"; color: Theme.palette.textMuted; font.pixelSize: 9; font.family: Theme.typography.publicSans }
+                                    LogosTextField {
+                                        Layout.fillWidth: true
+                                        placeholderText: "64 hex chars (manual override)"
+                                        font.family: "monospace"; font.pixelSize: 10
+                                        text: {
+                                            var vals = proposeDialog._accountValues
+                                            var ai = parent.parent.acctIdx  // RowLayout → vault picker ColumnLayout
+                                            return vals && vals[ai] ? vals[ai].seed : ""
+                                        }
+                                        onTextChanged: {
+                                            var ai = parent.parent.acctIdx
+                                            var vals = proposeDialog._accountValues.slice()
+                                            if (!vals[ai]) return
+                                            vals[ai] = {isAuth: vals[ai].isAuth, seed: text}
+                                            proposeDialog._accountValues = vals
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Generated args form — shown when an instruction is selected
+                ColumnLayout {
+                    visible: proposeDialog._selectedIx !== ""
+                    Layout.fillWidth: true; spacing: 8
+
+                    Text {
+                        visible: proposeDialog._selectedIxObj !== null && (proposeDialog._selectedIxObj.args || []).length === 0
+                        text: "No arguments required"
+                        color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                    }
+
+                    Repeater {
+                        model: proposeDialog._selectedIxObj ? (proposeDialog._selectedIxObj.args || []) : []
+                        delegate: ColumnLayout {
+                            Layout.fillWidth: true; spacing: 3
+                            RowLayout {
+                                Layout.fillWidth: true; spacing: 6
+                                Text {
+                                    text: modelData.name || ""
+                                    color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                                    Layout.fillWidth: true
+                                }
+                                Text {
+                                    text: typeof modelData.type === "string" ? modelData.type : JSON.stringify(modelData.type)
+                                    color: Theme.palette.textPlaceholder; font.pixelSize: 10; font.family: "monospace"
+                                }
+                            }
+                            LogosTextField {
+                                Layout.fillWidth: true
+                                placeholderText: typeof modelData.type === "string" ? modelData.type : JSON.stringify(modelData.type)
+                                onTextChanged: {
+                                    var vals = Object.assign({}, proposeDialog._argValues)
+                                    vals[modelData.name] = text
+                                    proposeDialog._argValues = vals
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Fallback raw args textarea — shown when no instruction is selected
+                ColumnLayout {
+                    visible: proposeDialog._selectedIx === ""
+                    Layout.fillWidth: true; spacing: 4
+                    Text { text: "Args (JSON object)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
+                    TextArea {
+                        id: pArgsJson; Layout.fillWidth: true; implicitHeight: 60
+                        placeholderText: '{"amount": 1000, "recipient": "0x01020304…"}'
+                        color: Theme.palette.text; font.pixelSize: 11; font.family: "monospace"
+                        placeholderTextColor: Theme.palette.textPlaceholder
+                        wrapMode: TextArea.WrapAtWordBoundaryOrAnywhere
+                        background: Rectangle {
+                            color: Theme.palette.backgroundSecondary
+                            border.color: Theme.palette.border; radius: Theme.spacing.radiusSmall
+                        }
+                    }
+                }
+
+                Text {
+                    visible: proposeDialog._encodeError !== ""
+                    text: proposeDialog._encodeError
+                    color: Theme.palette.error; font.pixelSize: 10; font.family: Theme.typography.publicSans
+                    wrapMode: Text.WordWrap; Layout.fillWidth: true
                 }
             }
 
-            // ── Common: account count + proposal index ─────────────────────
-            RowLayout {
-                Layout.fillWidth: true; spacing: 12
-                ColumnLayout {
-                    Layout.fillWidth: true; spacing: 4
-                    Text { text: "Target account count"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-                    LogosTextField { id: pAcctCount; Layout.fillWidth: true; placeholderText: "0" }
-                }
-                ColumnLayout {
-                    Layout.fillWidth: true; spacing: 4
-                    Text { text: "Proposal index"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-                    LogosTextField {
-                        id: pPropIdx; Layout.fillWidth: true
-                        placeholderText: String(parseInt(backend.multisigState["transaction_index"]) || 0)
-                    }
-                }
+            // ── Raw mode only: account count (IDL mode derives it from instruction accounts) ──
+            ColumnLayout {
+                visible: proposeDialog.proposeMode === 0
+                Layout.fillWidth: true; spacing: 4
+                Text { text: "Target account count"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
+                LogosTextField { id: pAcctCount; Layout.fillWidth: true; placeholderText: "0" }
             }
-        }
+        } // ColumnLayout proposeContent
+
+        } // ScrollView
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton {
                 text: "Cancel"
-                onClicked: { proposeDialog.close(); proposeDialog.proposeMode = 0 }
+                onClicked: { proposeDialog.close(); proposeDialog.proposeMode = 0; proposeDialog._selectedIx = ""; proposeDialog._argValues = ({}); proposeDialog._accountValues = []; proposeDialog._selectedPresetLabel = "" }
             }
             // In encode mode, show Encode button only; in raw mode, show Propose
             Rectangle {
@@ -1461,15 +2660,26 @@ Item {
                             var instrWords = pInstrData.text.split("\n")
                                 .map(function(s){ return s.trim() })
                                 .filter(function(s){ return s.length > 0 })
-                            var propIdx = pPropIdx.text.length > 0
-                                ? pPropIdx.text
-                                : String(parseInt(backend.multisigState["transaction_index"]) || 0)
+                            var propIdx = String(parseInt(backend.multisigState["transaction_index"]) || 0)
+                            var acctVals = proposeDialog._accountValues
+                            var pdaSeeds = [], authIdx = []
+                            for (var ai = 0; ai < acctVals.length; ai++) {
+                                if (acctVals[ai] && acctVals[ai].isAuth) {
+                                    authIdx.push(ai)
+                                    if (acctVals[ai].seed) pdaSeeds.push(acctVals[ai].seed)
+                                }
+                            }
+                            var acctCount = acctVals.length > 0 ? acctVals.length : (parseInt(pAcctCount.text) || 0)
                             backend.propose(pProposerId.text.trim(), pTargetProgram.text.trim(),
-                                            instrWords, parseInt(pAcctCount.text) || 0,
-                                            [], [], activeCreateKey, propIdx)
+                                            instrWords, acctCount,
+                                            pdaSeeds, authIdx, activeCreateKey, propIdx)
                             proposeDialog.close()
                             proposeDialog.proposeMode = 0
                             proposeDialog._encodePreview = ""
+                            proposeDialog._selectedIx = ""
+                            proposeDialog._argValues = ({})
+                            proposeDialog._accountValues = []
+                            proposeDialog._selectedPresetLabel = ""
                         }
                     }
                 }
@@ -1483,10 +2693,11 @@ Item {
         title: "Propose Add Member"
         modal: true; anchors.centerIn: parent
         width: Math.min(420, parent.width - 48)
+        contentHeight: addMemberContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: addMemberDialog.title; color: Theme.palette.text
@@ -1495,23 +2706,19 @@ Item {
         }
 
         ColumnLayout {
+            id: addMemberContent
             width: parent.width; spacing: 10
 
             Text { text: "Proposer account ID"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: amProposerId; Layout.fillWidth: true; placeholderText: "your account ID" }
+            AccountField { id: amProposerId; historyKey: "proposer_id"; placeholderText: "your account ID" }
 
             Text { text: "New member account ID (fresh keypair)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: amNewMember; Layout.fillWidth: true; placeholderText: "fresh keypair account ID" }
+            AccountField { id: amNewMember; historyKey: "member_id"; placeholderText: "fresh keypair account ID" }
 
-            Text { text: "Proposal index"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField {
-                id: amPropIdx; Layout.fillWidth: true
-                placeholderText: String(parseInt(backend.multisigState["transaction_index"]) || 0)
-            }
         }
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton { text: "Cancel"; onClicked: addMemberDialog.close() }
             Rectangle {
@@ -1527,9 +2734,7 @@ Item {
                     id: amOkArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
                     onClicked: {
                         if (!backend.busy) {
-                            var propIdx = amPropIdx.text.length > 0
-                                ? amPropIdx.text
-                                : String(parseInt(backend.multisigState["transaction_index"]) || 0)
+                            var propIdx = String(parseInt(backend.multisigState["transaction_index"]) || 0)
                             backend.proposeAddMember(amProposerId.text.trim(), amNewMember.text.trim(),
                                                      activeCreateKey, propIdx)
                             addMemberDialog.close()
@@ -1546,10 +2751,11 @@ Item {
         title: "Propose Remove Member"
         modal: true; anchors.centerIn: parent
         width: Math.min(420, parent.width - 48)
+        contentHeight: removeMemberContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: removeMemberDialog.title; color: Theme.palette.text
@@ -1558,23 +2764,19 @@ Item {
         }
 
         ColumnLayout {
+            id: removeMemberContent
             width: parent.width; spacing: 10
 
             Text { text: "Proposer account ID"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: rmProposerId; Layout.fillWidth: true; placeholderText: "your account ID" }
+            AccountField { id: rmProposerId; historyKey: "proposer_id"; placeholderText: "your account ID" }
 
             Text { text: "Member to remove (account ID)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: rmMember; Layout.fillWidth: true; placeholderText: "account ID to remove" }
+            AccountField { id: rmMember; historyKey: "member_id"; showCurrentMembers: true; placeholderText: "account ID to remove" }
 
-            Text { text: "Proposal index"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField {
-                id: rmPropIdx; Layout.fillWidth: true
-                placeholderText: String(parseInt(backend.multisigState["transaction_index"]) || 0)
-            }
         }
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton { text: "Cancel"; onClicked: removeMemberDialog.close() }
             Rectangle {
@@ -1590,9 +2792,7 @@ Item {
                     id: rmOkArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
                     onClicked: {
                         if (!backend.busy) {
-                            var propIdx = rmPropIdx.text.length > 0
-                                ? rmPropIdx.text
-                                : String(parseInt(backend.multisigState["transaction_index"]) || 0)
+                            var propIdx = String(parseInt(backend.multisigState["transaction_index"]) || 0)
                             backend.proposeRemoveMember(rmProposerId.text.trim(), rmMember.text.trim(),
                                                         activeCreateKey, propIdx)
                             removeMemberDialog.close()
@@ -1609,10 +2809,11 @@ Item {
         title: "Propose Change Threshold"
         modal: true; anchors.centerIn: parent
         width: Math.min(420, parent.width - 48)
+        contentHeight: changeThresholdContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: changeThresholdDialog.title; color: Theme.palette.text
@@ -1621,6 +2822,7 @@ Item {
         }
 
         ColumnLayout {
+            id: changeThresholdContent
             width: parent.width; spacing: 10
 
             Text {
@@ -1630,20 +2832,15 @@ Item {
             }
 
             Text { text: "Proposer account ID"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField { id: ctProposerId; Layout.fillWidth: true; placeholderText: "your account ID" }
+            AccountField { id: ctProposerId; historyKey: "proposer_id"; placeholderText: "your account ID" }
 
             Text { text: "New threshold (M)"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
             LogosTextField { id: ctNewThreshold; Layout.fillWidth: true; placeholderText: "e.g. 3" }
 
-            Text { text: "Proposal index"; color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans }
-            LogosTextField {
-                id: ctPropIdx; Layout.fillWidth: true
-                placeholderText: String(parseInt(backend.multisigState["transaction_index"]) || 0)
-            }
         }
 
         footer: RowLayout {
-            spacing: 8; Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton { text: "Cancel"; onClicked: changeThresholdDialog.close() }
             Rectangle {
@@ -1659,9 +2856,7 @@ Item {
                     id: ctOkArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
                     onClicked: {
                         if (!backend.busy && ctNewThreshold.text.length > 0) {
-                            var propIdx = ctPropIdx.text.length > 0
-                                ? ctPropIdx.text
-                                : String(parseInt(backend.multisigState["transaction_index"]) || 0)
+                            var propIdx = String(parseInt(backend.multisigState["transaction_index"]) || 0)
                             backend.proposeChangeThreshold(ctProposerId.text.trim(),
                                                            parseInt(ctNewThreshold.text),
                                                            activeCreateKey, propIdx)
@@ -1678,12 +2873,38 @@ Item {
         id: accountPicker
         property string action: ""
         property int proposalIndex: 0
+        property var proposalData: null
+        property var _extAccts: ({})   // slot index → user-typed account ID (non-PDA slots)
+        onOpened: { _extAccts = {} }
+
+        // Build the target_accounts array for execute from PDA seeds + user-entered external accounts.
+        function buildTargetAccounts() {
+            var pd = proposalData
+            var count = pd ? (parseInt(pd["target_account_count"]) || 0) : 0
+            var seeds = pd ? (pd["pda_seeds"] || []) : []
+            var authIdx = pd ? (pd["authorized_indices"] || []) : []
+            var result = []
+            for (var i = 0; i < count; i++) {
+                var pdaPos = -1
+                for (var j = 0; j < authIdx.length; j++) {
+                    if (parseInt(authIdx[j]) === i) { pdaPos = j; break }
+                }
+                if (pdaPos >= 0) {
+                    result.push(backend.pdaFromSeed(seeds[pdaPos] || ""))
+                } else {
+                    result.push(_extAccts[i] || "")
+                }
+            }
+            return result
+        }
+
         modal: true; anchors.centerIn: parent
-        width: Math.min(420, parent.width - 48)
+        width: Math.min(480, parent.width - 48)
+        contentHeight: accountPickerContent.implicitHeight
         background: Rectangle { color: Theme.palette.backgroundSecondary; border.color: Theme.palette.border; radius: Theme.spacing.radiusLarge }
 
         header: Item {
-            height: 52
+            implicitHeight: 52
             Text {
                 anchors { left: parent.left; verticalCenter: parent.verticalCenter; leftMargin: 20 }
                 text: accountPicker.action + " Proposal #" + accountPicker.proposalIndex
@@ -1693,7 +2914,65 @@ Item {
         }
 
         ColumnLayout {
+            id: accountPickerContent
             width: parent.width; spacing: 8
+
+            // ── Target accounts (Execute only) ────────────────────────────
+            ColumnLayout {
+                visible: accountPicker.action === "Execute" &&
+                         accountPicker.proposalData !== null &&
+                         (parseInt(accountPicker.proposalData["target_account_count"]) || 0) > 0
+                Layout.fillWidth: true; spacing: 4
+
+                Text {
+                    text: "Target accounts"
+                    color: Theme.palette.textMuted; font.pixelSize: 11; font.family: Theme.typography.publicSans
+                }
+
+                Repeater {
+                    model: accountPicker.proposalData ? (parseInt(accountPicker.proposalData["target_account_count"]) || 0) : 0
+                    delegate: ColumnLayout {
+                        Layout.fillWidth: true; spacing: 2
+                        property int slotIdx: index
+                        property var _seeds: accountPicker.proposalData ? (accountPicker.proposalData["pda_seeds"] || []) : []
+                        property var _auth:  accountPicker.proposalData ? (accountPicker.proposalData["authorized_indices"] || []) : []
+                        property int pdaPos: {
+                            for (var j = 0; j < _auth.length; j++) {
+                                if (parseInt(_auth[j]) === slotIdx) return j
+                            }
+                            return -1
+                        }
+                        property bool isPda: pdaPos >= 0
+                        property string pdaId: isPda ? backend.pdaFromSeed(_seeds[pdaPos] || "") : ""
+
+                        Text {
+                            text: "Account " + parent.slotIdx + (parent.isPda ? "  (PDA — auto)" : "  (external)")
+                            color: Theme.palette.textMuted; font.pixelSize: 10; font.family: Theme.typography.publicSans
+                        }
+                        Text {
+                            visible: parent.isPda
+                            Layout.fillWidth: true
+                            text: parent.pdaId || "(computing...)"
+                            color: Theme.palette.textMuted
+                            font.pixelSize: 11; font.family: Theme.typography.publicSans
+                            elide: Text.ElideMiddle
+                        }
+                        LogosTextField {
+                            visible: !parent.isPda
+                            Layout.fillWidth: true
+                            text: accountPicker._extAccts[parent.slotIdx] || ""
+                            placeholderText: "account ID"
+                            onTextChanged: {
+                                var m = Object.assign({}, accountPicker._extAccts)
+                                m[parent.slotIdx] = text.trim()
+                                accountPicker._extAccts = m
+                            }
+                        }
+                    }
+                }
+
+                Rectangle { Layout.fillWidth: true; height: 1; color: Theme.palette.border; Layout.topMargin: 4; Layout.bottomMargin: 4 }
+            }
 
             Text {
                 text: "Select your account"
@@ -1704,11 +2983,54 @@ Item {
             Repeater {
                 model: backend.walletAccounts
                 delegate: Rectangle {
+                    id: pickerRow
+                    property string acctId: modelData["id"] || ""
+                    property bool isPreconfigured: (modelData["path"] || "").indexOf("Preconfigured") >= 0
+                    property bool isMember: {
+                        var mems = membersHex()
+                        var myKey = acctId.replace(/^(Public|Private)\//, "")
+                        for (var i = 0; i < mems.length; i++) {
+                            if (mems[i].replace(/^(Public|Private)\//, "") === myKey) return true
+                        }
+                        return false
+                    }
+                    property bool alreadyApproved: {
+                        var pd = accountPicker.proposalData
+                        if (!pd) return false
+                        var appr = pd["approved"] || []
+                        var myKey = acctId.replace(/^(Public|Private)\//, "")
+                        for (var i = 0; i < appr.length; i++) {
+                            var entry = appr[i]
+                            var entryKey = typeof entry === "string"
+                                ? entry.replace(/^(Public|Private)\//, "")
+                                : u8ArrayToHex(entry)
+                            if (entryKey === myKey) return true
+                        }
+                        return false
+                    }
+                    property bool canAct: {
+                        if (isPreconfigured || !isMember) return false
+                        if (accountPicker.action === "Approve" && alreadyApproved) return false
+                        return true
+                    }
+                    property string statusLabel: {
+                        if (isPreconfigured) return "Cannot sign"
+                        if (!isMember)       return "Not a member"
+                        if (accountPicker.action === "Approve" && alreadyApproved) return "Already approved"
+                        return "Member"
+                    }
+                    property color statusColor: {
+                        if (isPreconfigured || !isMember) return Theme.palette.textMuted
+                        if (accountPicker.action === "Approve" && alreadyApproved) return Theme.palette.textMuted
+                        return Theme.palette.success
+                    }
+
                     Layout.fillWidth: true; height: 44; radius: Theme.spacing.radiusLarge
-                    color: pickArea.containsMouse
+                    opacity: canAct ? 1.0 : 0.5
+                    color: (pickArea.containsMouse && canAct)
                         ? Qt.rgba(Theme.palette.primary.r, Theme.palette.primary.g, Theme.palette.primary.b, 0.12)
                         : Theme.palette.background
-                    border.color: pickArea.containsMouse ? Theme.palette.primary : Theme.palette.border
+                    border.color: (pickArea.containsMouse && canAct) ? Theme.palette.primary : Theme.palette.border
 
                     RowLayout {
                         anchors { fill: parent; margins: 10 }
@@ -1722,17 +3044,31 @@ Item {
                             visible: !!modelData["label"]
                             text: shortHex(modelData["id"] || "")
                             color: Theme.palette.textMuted
-                            font.pixelSize: 11; elide: Text.ElideRight; Layout.preferredWidth: 120
+                            font.pixelSize: 11; elide: Text.ElideRight; Layout.preferredWidth: 90
+                        }
+                        Text {
+                            text: pickerRow.statusLabel
+                            color: pickerRow.statusColor
+                            font.pixelSize: 10; font.family: Theme.typography.publicSans
                         }
                     }
 
                     MouseArea {
-                        id: pickArea; anchors.fill: parent; cursorShape: Qt.PointingHandCursor; hoverEnabled: true
+                        id: pickArea; anchors.fill: parent
+                        cursorShape: pickerRow.canAct ? Qt.PointingHandCursor : Qt.ForbiddenCursor
+                        hoverEnabled: true
                         onClicked: {
+                            if (!pickerRow.canAct) return
                             var acctId = modelData["id"] || ""
                             if      (accountPicker.action === "Approve") backend.approve(acctId, accountPicker.proposalIndex, activeCreateKey)
                             else if (accountPicker.action === "Reject")  backend.reject(acctId, accountPicker.proposalIndex, activeCreateKey)
-                            else if (accountPicker.action === "Execute") backend.execute(acctId, accountPicker.proposalIndex, activeCreateKey)
+                            else if (accountPicker.action === "Execute") {
+                                var tc = accountPicker.proposalData ? (parseInt(accountPicker.proposalData["target_account_count"]) || 0) : 0
+                                if (tc > 0)
+                                    backend.executeWithAccounts(acctId, accountPicker.proposalIndex, activeCreateKey, accountPicker.buildTargetAccounts())
+                                else
+                                    backend.execute(acctId, accountPicker.proposalIndex, activeCreateKey)
+                            }
                             accountPicker.close()
                         }
                     }
@@ -1748,7 +3084,7 @@ Item {
         }
 
         footer: RowLayout {
-            Layout.rightMargin: 16; Layout.bottomMargin: 12
+            spacing: 8
             Item { Layout.fillWidth: true }
             LogosButton { text: "Cancel"; onClicked: accountPicker.close() }
         }

--- a/lez-multisig-module/src/LezStorageBridge.h
+++ b/lez-multisig-module/src/LezStorageBridge.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <QObject>
+
+#ifdef LOGOS_STORAGE_AVAILABLE
+#include "storage_module_api.h"
+#include <memory>
+#else
+class LogosAPI;
+#endif
+
+// Wraps the Logos Storage module for IDL fetching via native IPC.
+// Exposed to QML as "storage" context property.
+class LezStorageBridge : public QObject {
+    Q_OBJECT
+public:
+    explicit LezStorageBridge(LogosAPI* api, QObject* parent = nullptr)
+        : QObject(parent)
+    {
+#ifdef LOGOS_STORAGE_AVAILABLE
+        if (api) m_storage = std::make_unique<StorageModule>(api);
+#else
+        Q_UNUSED(api)
+#endif
+    }
+
+    // Returns the raw IDL JSON content for cid, or "" on failure.
+    Q_INVOKABLE QString fetchIdl(const QString& cid) {
+#ifdef LOGOS_STORAGE_AVAILABLE
+        if (m_storage) {
+            auto r = m_storage->fetch(cid);
+            if (r.success) return r.getString();
+        }
+#else
+        Q_UNUSED(cid)
+#endif
+        return {};
+    }
+
+private:
+#ifdef LOGOS_STORAGE_AVAILABLE
+    std::unique_ptr<StorageModule> m_storage;
+#endif
+};

--- a/lez-multisig-module/vendor/storage_module_api/storage_module_api.cpp
+++ b/lez-multisig-module/vendor/storage_module_api/storage_module_api.cpp
@@ -1,0 +1,475 @@
+#include "storage_module_api.h"
+
+#include <QDebug>
+
+StorageModule::StorageModule(LogosAPI* api) : m_api(api), m_client(api->getClient("storage_module")), m_moduleName(QStringLiteral("storage_module")) {}
+
+LogosObject* StorageModule::ensureReplica() {
+    if (!m_eventReplica) {
+        LogosObject* replica = m_client->requestObject(m_moduleName);
+        if (!replica) {
+            qWarning() << "StorageModule: failed to acquire remote object for events on" << m_moduleName;
+            return nullptr;
+        }
+        m_eventReplica = replica;
+    }
+    return m_eventReplica;
+}
+
+bool StorageModule::on(const QString& eventName, RawEventCallback callback) {
+    if (!callback) {
+        qWarning() << "StorageModule: ignoring empty event callback for" << eventName;
+        return false;
+    }
+    LogosObject* origin = ensureReplica();
+    if (!origin) {
+        return false;
+    }
+    m_client->onEvent(origin, eventName, callback);
+    return true;
+}
+
+bool StorageModule::on(const QString& eventName, EventCallback callback) {
+    if (!callback) {
+        qWarning() << "StorageModule: ignoring empty event callback for" << eventName;
+        return false;
+    }
+    return on(eventName, [callback](const QString&, const QVariantList& data) {
+        callback(data);
+    });
+}
+
+void StorageModule::setEventSource(LogosObject* source) {
+    m_eventSource = source;
+}
+
+LogosObject* StorageModule::eventSource() const {
+    return m_eventSource;
+}
+
+void StorageModule::trigger(const QString& eventName) {
+    trigger(eventName, QVariantList{});
+}
+
+void StorageModule::trigger(const QString& eventName, const QVariantList& data) {
+    if (!m_eventSource) {
+        qWarning() << "StorageModule: no event source set for trigger" << eventName;
+        return;
+    }
+    m_client->onEventResponse(m_eventSource, eventName, data);
+}
+
+void StorageModule::trigger(const QString& eventName, LogosObject* source, const QVariantList& data) {
+    if (!source) {
+        qWarning() << "StorageModule: cannot trigger" << eventName << "with null source";
+        return;
+    }
+    m_client->onEventResponse(source, eventName, data);
+}
+
+bool StorageModule::init(const QString& cfg) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "init", cfg);
+    return _result.toBool();
+}
+
+void StorageModule::initAsync(const QString& cfg, std::function<void(bool)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "init", QVariantList() << cfg, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<bool>(v) : false);
+    }, timeout);
+}
+
+bool StorageModule::start() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "start");
+    return _result.toBool();
+}
+
+void StorageModule::startAsync(std::function<void(bool)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "start", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<bool>(v) : false);
+    }, timeout);
+}
+
+LogosResult StorageModule::version() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "version");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::versionAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "version", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::dataDir() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "dataDir");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::dataDirAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "dataDir", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::peerId() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "peerId");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::peerIdAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "peerId", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::debug() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "debug");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::debugAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "debug", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::spr() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "spr");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::sprAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "spr", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::updateLogLevel(const QString& logLevel) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "updateLogLevel", logLevel);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::updateLogLevelAsync(const QString& logLevel, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "updateLogLevel", QVariantList() << logLevel, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::connect(const QString& peerId, const QStringList& peerAddresses) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "connect", peerId, peerAddresses);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::connectAsync(const QString& peerId, const QStringList& peerAddresses, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "connect", QVariantList{peerId, peerAddresses}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadUrl(QVariant url, int chunkSize) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadUrl", url, chunkSize);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadUrlAsync(QVariant url, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadUrl", QVariantList{url, chunkSize}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadUrl(QVariant url) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadUrl", url);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadUrlAsync(QVariant url, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadUrl", QVariantList() << url, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadInit(const QString& filename, int chunkSize) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadInit", filename, chunkSize);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadInitAsync(const QString& filename, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadInit", QVariantList{filename, chunkSize}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadInit(const QString& filename) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadInit", filename);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadInitAsync(const QString& filename, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadInit", QVariantList() << filename, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadChunk(const QString& sessionId, QVariant chunk) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadChunk", sessionId, chunk);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadChunkAsync(const QString& sessionId, QVariant chunk, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadChunk", QVariantList{sessionId, chunk}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadFinalize(const QString& sessionId) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadFinalize", sessionId);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadFinalizeAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadFinalize", QVariantList() << sessionId, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::uploadCancel(const QString& sessionId) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "uploadCancel", sessionId);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::uploadCancelAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "uploadCancel", QVariantList() << sessionId, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadCancel(const QString& sessionId) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadCancel", sessionId);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadCancelAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadCancel", QVariantList() << sessionId, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadToUrl(const QString& cid, QVariant url, bool local, int chunkSize) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadToUrl", cid, url, local, chunkSize);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadToUrlAsync(const QString& cid, QVariant url, bool local, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadToUrl", QVariantList{cid, url, local, chunkSize}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadToUrl(const QString& cid, QVariant url, bool local) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadToUrl", cid, url, local);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadToUrlAsync(const QString& cid, QVariant url, bool local, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadToUrl", QVariantList{cid, url, local}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadToUrl(const QString& cid, QVariant url) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadToUrl", cid, url);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadToUrlAsync(const QString& cid, QVariant url, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadToUrl", QVariantList{cid, url}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadChunks(const QString& cid, bool local, int chunkSize, const QString& filepath) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadChunks", cid, local, chunkSize, filepath);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadChunksAsync(const QString& cid, bool local, int chunkSize, const QString& filepath, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadChunks", QVariantList{cid, local, chunkSize, filepath}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadChunks(const QString& cid, bool local, int chunkSize) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadChunks", cid, local, chunkSize);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadChunksAsync(const QString& cid, bool local, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadChunks", QVariantList{cid, local, chunkSize}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadChunks(const QString& cid, bool local) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadChunks", cid, local);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadChunksAsync(const QString& cid, bool local, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadChunks", QVariantList{cid, local}, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadChunks(const QString& cid) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadChunks", cid);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadChunksAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadChunks", QVariantList() << cid, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::exists(const QString& cid) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "exists", cid);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::existsAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "exists", QVariantList() << cid, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::fetch(const QString& cid) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "fetch", cid);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::fetchAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "fetch", QVariantList() << cid, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::remove(const QString& cid) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "remove", cid);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::removeAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "remove", QVariantList() << cid, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::space() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "space");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::spaceAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "space", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::manifests() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "manifests");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::manifestsAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "manifests", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::downloadManifest(const QString& cid) {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "downloadManifest", cid);
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::downloadManifestAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "downloadManifest", QVariantList() << cid, [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::stop() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "stop");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::stopAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "stop", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+LogosResult StorageModule::destroy() {
+    QVariant _result = m_client->invokeRemoteMethod("storage_module", "destroy");
+    return _result.value<LogosResult>();
+}
+
+void StorageModule::destroyAsync(std::function<void(LogosResult)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "destroy", QVariantList(), [callback](QVariant v) {
+        callback(v.isValid() ? qvariant_cast<LogosResult>(v) : LogosResult{});
+    }, timeout);
+}
+
+void StorageModule::importFiles(const QString& path) {
+    m_client->invokeRemoteMethod("storage_module", "importFiles", path);
+}
+
+void StorageModule::importFilesAsync(const QString& path, std::function<void(void)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "importFiles", QVariantList() << path, [callback](QVariant v) {
+        callback();
+    }, timeout);
+}
+
+void StorageModule::initLogos(QVariant logosAPIInstance) {
+    m_client->invokeRemoteMethod("storage_module", "initLogos", logosAPIInstance);
+}
+
+void StorageModule::initLogosAsync(QVariant logosAPIInstance, std::function<void(void)> callback, Timeout timeout) {
+    if (!callback) return;
+    m_client->invokeRemoteMethodAsync("storage_module", "initLogos", QVariantList() << logosAPIInstance, [callback](QVariant v) {
+        callback();
+    }, timeout);
+}
+

--- a/lez-multisig-module/vendor/storage_module_api/storage_module_api.h
+++ b/lez-multisig-module/vendor/storage_module_api/storage_module_api.h
@@ -1,0 +1,122 @@
+#pragma once
+#include <QString>
+#include <QVariant>
+#include <QStringList>
+#include <QJsonArray>
+#include <QVariantList>
+#include <QVariantMap>
+#include <functional>
+#include <utility>
+#include "logos_types.h"
+#include "logos_api.h"
+#include "logos_api_client.h"
+#include "logos_object.h"
+
+class StorageModule {
+public:
+    explicit StorageModule(LogosAPI* api);
+
+    using RawEventCallback = std::function<void(const QString&, const QVariantList&)>;
+    using EventCallback = std::function<void(const QVariantList&)>;
+
+    bool on(const QString& eventName, RawEventCallback callback);
+    bool on(const QString& eventName, EventCallback callback);
+    void setEventSource(LogosObject* source);
+    LogosObject* eventSource() const;
+    void trigger(const QString& eventName);
+    void trigger(const QString& eventName, const QVariantList& data);
+    template<typename... Args>
+    void trigger(const QString& eventName, Args&&... args) {
+        trigger(eventName, packVariantList(std::forward<Args>(args)...));
+    }
+    void trigger(const QString& eventName, LogosObject* source, const QVariantList& data);
+    template<typename... Args>
+    void trigger(const QString& eventName, LogosObject* source, Args&&... args) {
+        trigger(eventName, source, packVariantList(std::forward<Args>(args)...));
+    }
+
+    bool init(const QString& cfg);
+    void initAsync(const QString& cfg, std::function<void(bool)> callback, Timeout timeout = Timeout());
+    bool start();
+    void startAsync(std::function<void(bool)> callback, Timeout timeout = Timeout());
+    LogosResult version();
+    void versionAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult dataDir();
+    void dataDirAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult peerId();
+    void peerIdAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult debug();
+    void debugAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult spr();
+    void sprAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult updateLogLevel(const QString& logLevel);
+    void updateLogLevelAsync(const QString& logLevel, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult connect(const QString& peerId, const QStringList& peerAddresses);
+    void connectAsync(const QString& peerId, const QStringList& peerAddresses, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadUrl(QVariant url, int chunkSize);
+    void uploadUrlAsync(QVariant url, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadUrl(QVariant url);
+    void uploadUrlAsync(QVariant url, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadInit(const QString& filename, int chunkSize);
+    void uploadInitAsync(const QString& filename, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadInit(const QString& filename);
+    void uploadInitAsync(const QString& filename, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadChunk(const QString& sessionId, QVariant chunk);
+    void uploadChunkAsync(const QString& sessionId, QVariant chunk, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadFinalize(const QString& sessionId);
+    void uploadFinalizeAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult uploadCancel(const QString& sessionId);
+    void uploadCancelAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadCancel(const QString& sessionId);
+    void downloadCancelAsync(const QString& sessionId, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadToUrl(const QString& cid, QVariant url, bool local, int chunkSize);
+    void downloadToUrlAsync(const QString& cid, QVariant url, bool local, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadToUrl(const QString& cid, QVariant url, bool local);
+    void downloadToUrlAsync(const QString& cid, QVariant url, bool local, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadToUrl(const QString& cid, QVariant url);
+    void downloadToUrlAsync(const QString& cid, QVariant url, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadChunks(const QString& cid, bool local, int chunkSize, const QString& filepath);
+    void downloadChunksAsync(const QString& cid, bool local, int chunkSize, const QString& filepath, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadChunks(const QString& cid, bool local, int chunkSize);
+    void downloadChunksAsync(const QString& cid, bool local, int chunkSize, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadChunks(const QString& cid, bool local);
+    void downloadChunksAsync(const QString& cid, bool local, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadChunks(const QString& cid);
+    void downloadChunksAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult exists(const QString& cid);
+    void existsAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult fetch(const QString& cid);
+    void fetchAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult remove(const QString& cid);
+    void removeAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult space();
+    void spaceAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult manifests();
+    void manifestsAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult downloadManifest(const QString& cid);
+    void downloadManifestAsync(const QString& cid, std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult stop();
+    void stopAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    LogosResult destroy();
+    void destroyAsync(std::function<void(LogosResult)> callback, Timeout timeout = Timeout());
+    void importFiles(const QString& path);
+    void importFilesAsync(const QString& path, std::function<void()> callback, Timeout timeout = Timeout());
+    void initLogos(QVariant logosAPIInstance);
+    void initLogosAsync(QVariant logosAPIInstance, std::function<void()> callback, Timeout timeout = Timeout());
+
+private:
+    LogosObject* ensureReplica();
+    template<typename... Args>
+    static QVariantList packVariantList(Args&&... args) {
+        QVariantList list;
+        list.reserve(sizeof...(Args));
+        using Expander = int[];
+        (void)Expander{0, (list.append(QVariant::fromValue(std::forward<Args>(args))), 0)...};
+        return list;
+    }
+    LogosAPI* m_api;
+    LogosAPIClient* m_client;
+    QString m_moduleName;
+    LogosObject* m_eventReplica = nullptr;
+    LogosObject* m_eventSource = nullptr;
+};

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
 serde_json = "1"

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -18,5 +18,5 @@ multisig_program = { path = "../../multisig_program" }
 nssa_core.workspace = true
 risc0-zkvm.workspace = true
 borsh.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }
 serde_json = "1"

--- a/multisig_core/Cargo.toml
+++ b/multisig_core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh = "1.5.7"
-spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }

--- a/multisig_core/Cargo.toml
+++ b/multisig_core/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh = "1.5.7"
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.4.0" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true

--- a/multisig_program/Cargo.toml
+++ b/multisig_program/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 multisig_core = { path = "../multisig_core" }
 nssa_core.workspace = true
-spel-framework = { git = "https://github.com/logos-co/spel.git", rev = "4a1b89a0f64fc8ec66492b45514f54d705a1be90" }
+spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v0.6.0" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 borsh.workspace = true
 risc0-zkvm.workspace = true

--- a/multisig_program/src/lib.rs
+++ b/multisig_program/src/lib.rs
@@ -40,7 +40,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn propose(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         proposer: AccountWithMetadata,
@@ -71,7 +71,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn approve(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         approver: AccountWithMetadata,
@@ -91,7 +91,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn reject(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         rejector: AccountWithMetadata,
@@ -111,7 +111,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn execute(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         executor: AccountWithMetadata,
@@ -134,7 +134,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn propose_add_member(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         proposer: AccountWithMetadata,
@@ -157,7 +157,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn propose_remove_member(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         proposer: AccountWithMetadata,
@@ -180,7 +180,7 @@ mod multisig_program {
     /// proposal PDA seeds: ["multisig_prop___", create_key, proposal_index]
     #[instruction]
     pub fn propose_change_threshold(
-        #[account(mut)]
+        #[account(mut, pda = arg("create_key"))]
         multisig_state: AccountWithMetadata,
         #[account(signer)]
         proposer: AccountWithMetadata,

--- a/scripts/demo-full-flow.sh
+++ b/scripts/demo-full-flow.sh
@@ -45,12 +45,12 @@ TOKEN_BIN="$LSSA_DIR/artifacts/program_methods/token.bin"
 SEQUENCER_URL="${SEQUENCER_URL:-http://127.0.0.1:3040}"
 
 # Use a demo-local wallet dir so the demo never touches your real wallet storage
-# Override by setting NSSA_WALLET_HOME_DIR before running
+# Override by setting LEE_WALLET_HOME_DIR before running
 DEMO_WALLET_DIR="$MULTISIG_DIR/demo-wallet"
-export NSSA_WALLET_HOME_DIR="${NSSA_WALLET_HOME_DIR:-$DEMO_WALLET_DIR}"
+export LEE_WALLET_HOME_DIR="${LEE_WALLET_HOME_DIR:-$DEMO_WALLET_DIR}"
 
 # Ensure demo wallet dir exists (wallet CLI creates fresh accounts as needed)
-mkdir -p "$NSSA_WALLET_HOME_DIR"
+mkdir -p "$LEE_WALLET_HOME_DIR"
 # REGISTRY_PROGRAM_ID_HEX set dynamically from inspect below
 STORAGE_URL="http://127.0.0.1:8080"
 MOCK_CODEX_PY="$MULTISIG_DIR/scripts/mock-codex.py"
@@ -136,14 +136,14 @@ sleep 2
 # Wipe RocksDB state
 rm -rf "${LSSA_DIR}/sequencer_runner/rocksdb" "${LSSA_DIR}/sequencer_runner/mempool" "${LSSA_DIR}/rocksdb" "${LSSA_DIR}/mempool"
 # Reset wallet nonce cache
-cp "${NSSA_WALLET_HOME_DIR}/storage.json" "${NSSA_WALLET_HOME_DIR}/storage.json.bak" 2>/dev/null || true
-rm -f "${NSSA_WALLET_HOME_DIR}/storage.json"
+cp "${LEE_WALLET_HOME_DIR}/storage.json" "${LEE_WALLET_HOME_DIR}/storage.json.bak" 2>/dev/null || true
+rm -f "${LEE_WALLET_HOME_DIR}/storage.json"
 
 # Speed up tx confirmation polling for demo
-if command -v python3 &>/dev/null && [ -f "${NSSA_WALLET_HOME_DIR}/wallet_config.json" ]; then
+if command -v python3 &>/dev/null && [ -f "${LEE_WALLET_HOME_DIR}/wallet_config.json" ]; then
   python3 -c "
 import json, sys
-p = '${NSSA_WALLET_HOME_DIR}/wallet_config.json'
+p = '${LEE_WALLET_HOME_DIR}/wallet_config.json'
 with open(p) as f: c = json.load(f)
 c['seq_poll_timeout_millis'] = 3000
 c['seq_tx_poll_max_blocks'] = 30

--- a/scripts/demo-logoscore.sh
+++ b/scripts/demo-logoscore.sh
@@ -33,7 +33,7 @@ export PATH="$HOME/.nix-profile/bin:$PATH"
 LOGOSCORE="$HOME/logos-lez-multisig-module/result/bin/logoscore"
 MODULES_DIR="$HOME/logos-lez-multisig-module/result/modules"
 SEQUENCER_URL="${SEQUENCER_URL:-http://127.0.0.1:3040}"
-WALLET_DIR="${NSSA_WALLET_HOME_DIR:-$HOME/lez-multisig-framework/demo-wallet}"
+WALLET_DIR="${LEE_WALLET_HOME_DIR:-$HOME/lez-multisig-framework/demo-wallet}"
 MULTISIG_DIR="${MULTISIG_DIR:-$HOME/lez-multisig-framework}"
 
 # ── Colours ──────────────────────────────────────────────────────────────────

--- a/scripts/demo-v2.sh
+++ b/scripts/demo-v2.sh
@@ -45,8 +45,8 @@ SEQUENCER_URL="${SEQUENCER_URL:-http://127.0.0.1:3040}"
 
 # Demo-local wallet dir so we never touch your real wallet storage
 DEMO_WALLET_DIR="$MULTISIG_DIR/demo-wallet"
-export NSSA_WALLET_HOME_DIR="${NSSA_WALLET_HOME_DIR:-$DEMO_WALLET_DIR}"
-mkdir -p "$NSSA_WALLET_HOME_DIR"
+export LEE_WALLET_HOME_DIR="${LEE_WALLET_HOME_DIR:-$DEMO_WALLET_DIR}"
+mkdir -p "$LEE_WALLET_HOME_DIR"
 
 STORAGE_URL="http://127.0.0.1:8081"
 MOCK_CODEX_PY="$MULTISIG_DIR/scripts/mock-codex.py"
@@ -137,13 +137,13 @@ sleep 2
 # Nuke ALL rocksdb/mempool dirs the sequencer might use
 find "${LSSA_DIR}" -name rocksdb -type d -exec rm -rf {} + 2>/dev/null || true
 find "${LSSA_DIR}" -name mempool -type d -exec rm -rf {} + 2>/dev/null || true
-cp "${NSSA_WALLET_HOME_DIR}/storage.json" "${NSSA_WALLET_HOME_DIR}/storage.json.bak" 2>/dev/null || true
-rm -f "${NSSA_WALLET_HOME_DIR}/storage.json"
+cp "${LEE_WALLET_HOME_DIR}/storage.json" "${LEE_WALLET_HOME_DIR}/storage.json.bak" 2>/dev/null || true
+rm -f "${LEE_WALLET_HOME_DIR}/storage.json"
 
-if command -v python3 &>/dev/null && [ -f "${NSSA_WALLET_HOME_DIR}/wallet_config.json" ]; then
+if command -v python3 &>/dev/null && [ -f "${LEE_WALLET_HOME_DIR}/wallet_config.json" ]; then
   python3 -c "
 import json, sys
-p = '${NSSA_WALLET_HOME_DIR}/wallet_config.json'
+p = '${LEE_WALLET_HOME_DIR}/wallet_config.json'
 with open(p) as f: c = json.load(f)
 c['seq_poll_timeout_millis'] = 5000
 c['seq_tx_poll_max_blocks'] = 60


### PR DESCRIPTION
## Summary

- Bump all SPEL crate pins from `v0.4.0` tag to the v0.6.0 commit (`4a1b89a`)
- Bump all LEZ crate pins from `v0.2.0-rc3` to the `v0.2.0` release tag; add `nssa_core`/`nssa` → `lee_core`/`lee` aliases so existing import paths compile unchanged
- Rename `NSSA_WALLET_HOME_DIR` → `LEE_WALLET_HOME_DIR` in `lib.rs` and all demo scripts
- Fix `make install-tools` to handle `rev`-based SPEL pins (was broken when switching from `tag` to `rev`)
- Update e2e tests for LEZ v0.2.0 API: `NSSATransaction` → `LeeTransaction`, `Program::new(data)` → `Program::new(data.into())`

## Test plan

- [x] `make install-tools` — installs `spel-client-gen` v0.6.0 via `rev` pin
- [x] `make build-module` — Rust FFI + C++ plugin compile clean
- [x] `cargo check --workspace --exclude methods-guest` — all crates pass
- [x] `cargo run -p lez-multisig-idl-gen` — IDL regenerates without errors
- [x] `cargo tree -p lez-multisig-ffi -d` — no duplicate dependency versions
- [x] Plugin loads in Basecamp with no QML errors
- [ ] E2E tests against live sequencer — let CI handle this

🤖 Generated with [Claude Code](https://claude.com/claude-code)